### PR TITLE
エラーページ作成

### DIFF
--- a/frontend/src/components/layouts/Header.tsx
+++ b/frontend/src/components/layouts/Header.tsx
@@ -16,12 +16,7 @@ export const Header = () => {
             role="button"
             className="avatar btn btn-circle btn-ghost"
           >
-            <div className="w-10 rounded-full">
-              <img
-                alt="Tailwind CSS Navbar component"
-                src="https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.webp"
-              />
-            </div>
+            <div className="w-10 rounded-full"></div>
           </div>
           <ul
             tabIndex={0}

--- a/frontend/src/pages/404.tsx
+++ b/frontend/src/pages/404.tsx
@@ -1,0 +1,33 @@
+import { useRouter } from 'next/router'
+import { Layout } from '@/components/Layout'
+
+const NotFoundPage = () => {
+  const router = useRouter()
+
+  return (
+    <Layout>
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="w-96 rounded-lg bg-white p-6 text-center shadow-lg">
+          <h1 className="mb-4 text-5xl font-bold text-purple-600">404</h1>
+          <h2 className="mb-4 text-2xl font-semibold text-gray-600">
+            Not Found
+          </h2>
+          <h2 className="mb-4 text-xl font-semibold">
+            ページが見つかりませんでした
+          </h2>
+          <p className="mb-6 text-gray-600">
+            申し訳ありませんが、リクエストされたページは存在しません。
+          </p>
+          <button
+            onClick={() => router.push('/')}
+            className="btn btn-primary btn-lg w-full"
+          >
+            ホームに戻る
+          </button>
+        </div>
+      </div>
+    </Layout>
+  )
+}
+
+export default NotFoundPage

--- a/frontend/src/pages/500.tsx
+++ b/frontend/src/pages/500.tsx
@@ -1,0 +1,33 @@
+import { useRouter } from 'next/router'
+import { Layout } from '@/components/Layout'
+
+const ServerErrorPage = () => {
+  const router = useRouter()
+
+  return (
+    <Layout>
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="w-96 rounded-lg bg-white p-6 text-center shadow-lg">
+          <h1 className="mb-4 text-5xl font-bold text-red-600">500</h1>
+          <h2 className="mb-4 text-2xl font-semibold text-gray-600">
+            Internal Server Error
+          </h2>
+          <h2 className="mb-4 text-xl font-semibold">
+            サーバーエラーが発生しました
+          </h2>
+          <p className="mb-6 text-gray-600">
+            申し訳ありませんが、システムに技術的な問題が発生しました。復旧までしばらくお待ちください。
+          </p>
+          <button
+            onClick={() => router.push('/')}
+            className="btn btn-primary btn-lg w-full"
+          >
+            ホームに戻る
+          </button>
+        </div>
+      </div>
+    </Layout>
+  )
+}
+
+export default ServerErrorPage

--- a/frontend/src/pages/_document.tsx
+++ b/frontend/src/pages/_document.tsx
@@ -32,8 +32,6 @@ export default function Document() {
           content="プログラミングのエラー内容や解決方法を記録し、検索できるアプリ。"
         />
         <meta name="twitter:image" content="/twitter-image.png" />
-
-        <title>Bug Note</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <body>


### PR DESCRIPTION
## 概要

エラーページ作成

## 関連するissue番号

- #47

## 行ったこと

- 404と500のエラーページ作成
- ESLintのエラーのためコードを修正

## 動作確認

フロントエンド http://localhost:8080
バックエンド http://localhost:3100

## その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced dedicated error pages for 404 and 500 responses, offering clear messaging and a button to navigate back to the homepage.
  
- **Refactor**
  - Updated the header design by removing the avatar image for a cleaner interface.
  
- **Chores**
  - Modified the page metadata to update the browser tab title display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->