### PR TITLE
バグ一覧機能実装

### DIFF
--- a/backend/app/controllers/api/v1/bugs_controller.rb
+++ b/backend/app/controllers/api/v1/bugs_controller.rb
@@ -1,5 +1,12 @@
 class Api::V1::BugsController < Api::V1::BaseController
-  before_action :authenticate_user!
+  include Pagination
+
+  before_action :authenticate_user!, only: [:create]
+
+  def index
+    bugs = Bug.where(status: "published").includes(:user, :environments, :attempts, :references).order(created_at: :desc).page(params[:page] || 1).per(10)
+    render json: bugs, each_serializer: BugSerializer, status: :ok, meta: pagination(bugs), adapter: :json
+  end
 
   def create
     form = BugForm.new(bug_params, current_user)

--- a/backend/app/controllers/concerns/pagination.rb
+++ b/backend/app/controllers/concerns/pagination.rb
@@ -1,0 +1,10 @@
+module Pagination
+  extend ActiveSupport::Concern
+
+  def pagination(records)
+    {
+      current_page: records.current_page,
+      total_pages: records.total_pages,
+    }
+  end
+end

--- a/backend/app/forms/bug_form.rb
+++ b/backend/app/forms/bug_form.rb
@@ -7,7 +7,7 @@ class BugForm
   validates :title, presence: true, length: { maximum: 255 }
   validates :content, presence: true
   validate :solution_required_if_solved
-  validate :status_public_if_unsolved
+  validate :status_published_if_unsolved
   validate :valid_references_urls
   validate :valid_environments_name_and_version
 
@@ -55,8 +55,8 @@ class BugForm
       end
     end
 
-    def status_public_if_unsolved
-      if !is_solved && status == "public"
+    def status_published_if_unsolved
+      if !is_solved && status == "published"
         errors.add(:status, "未解決の場合公開できません")
       end
     end

--- a/backend/app/serializers/attempt_serializer.rb
+++ b/backend/app/serializers/attempt_serializer.rb
@@ -1,0 +1,3 @@
+class AttemptSerializer < ActiveModel::Serializer
+  attributes :id, :content
+end

--- a/backend/app/serializers/bug_serializer.rb
+++ b/backend/app/serializers/bug_serializer.rb
@@ -1,0 +1,37 @@
+class BugSerializer < ActiveModel::Serializer
+  attributes :id, :title, :error_message, :content, :expected_behavior,
+             :solution, :cause, :etc, :is_solved, :status, :created_at, :from_today
+
+  has_many :environments, serializer: EnvironmentSerializer
+  has_many :attempts, serializer: AttemptSerializer
+  has_many :references, serializer: ReferenceSerializer
+  has_one :user, serializer: UserSerializer
+
+  def created_at
+    object.created_at.strftime("%Y/%m/%d")
+  end
+
+  def from_today # rubocop:disable Metrics/AbcSize
+    now = Time.zone.now
+    created_at = object.created_at
+
+    months = (now.year - created_at.year) * 12 + now.month - created_at.month - ((now.day >= created_at.day) ? 0 : 1)
+    years = months.div(12)
+
+    return "#{years}年前" if years > 0
+    return "#{months}ヶ月前" if months > 0
+
+    seconds = (Time.zone.now - object.created_at).round
+
+    days = seconds / (60 * 60 * 24)
+    return "#{days}日前" if days.positive?
+
+    hours = seconds / (60 * 60)
+    return "#{hours}時間前" if hours.positive?
+
+    minutes = seconds / 60
+    return "#{minutes}分前" if minutes.positive?
+
+    "#{seconds}秒前"
+  end
+end

--- a/backend/app/serializers/environment_serializer.rb
+++ b/backend/app/serializers/environment_serializer.rb
@@ -1,0 +1,3 @@
+class EnvironmentSerializer < ActiveModel::Serializer
+  attributes :id, :category, :name, :version
+end

--- a/backend/app/serializers/reference_serializer.rb
+++ b/backend/app/serializers/reference_serializer.rb
@@ -1,0 +1,3 @@
+class ReferenceSerializer < ActiveModel::Serializer
+  attributes :id, :url
+end

--- a/backend/app/serializers/user_serializer.rb
+++ b/backend/app/serializers/user_serializer.rb
@@ -1,0 +1,3 @@
+class UserSerializer < ActiveModel::Serializer
+  attributes :id, :name, :nickname, :image
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
         resource :confirmations, only: [:update]
       end
       resources :categories, only: [:index]
-      resources :bugs, only: [:create]
+      resources :bugs, only: [:index, :create]
     end
   end
 

--- a/backend/spec/factories/bugs.rb
+++ b/backend/spec/factories/bugs.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     etc { Faker::Lorem.paragraph }
     status { "draft" }
     is_solved { false }
+    created_at { Time.zone.now }
     user
 
     after(:create) do |bug|

--- a/backend/spec/factories/environments.rb
+++ b/backend/spec/factories/environments.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :environment do
     category { "カテゴリー" }
-    name { Faker.name }
+    name { Faker::App.name }
     version { Faker::App.version }
     bug
   end

--- a/backend/spec/factories/environments.rb
+++ b/backend/spec/factories/environments.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :environment do
     category { "カテゴリー" }
-    name { Faker::Technology.name }
+    name { Faker.name }
     version { Faker::App.version }
     bug
   end

--- a/backend/spec/models/bug_form_spec.rb
+++ b/backend/spec/models/bug_form_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe BugForm, type: :model do
       end
 
       it "解決済の状態でステータスを公開にすると成功する" do
-        bug_form.status = "public"
+        bug_form.status = "published"
         bug_form.is_solved = true
         expect(bug_form).to be_valid
       end
@@ -86,7 +86,7 @@ RSpec.describe BugForm, type: :model do
       end
 
       it "下書きの状態でステータスを公開にすると失敗する" do
-        bug_form.status = "public"
+        bug_form.status = "published"
         expect(bug_form).to be_invalid
       end
 

--- a/backend/spec/requests/api/v1/bugs_spec.rb
+++ b/backend/spec/requests/api/v1/bugs_spec.rb
@@ -1,9 +1,69 @@
 require "rails_helper"
 
 RSpec.describe "Api::V1::Bug", type: :request do
+  let!(:user) { create(:user) }
+  let(:headers) { user.create_new_auth_token }
+
+  describe "GET /api/v1/bugs" do
+    let!(:bugs) { create_list(:bug, 30, user: user, status: "published") }
+    let!(:unpublished_bug) { create(:bug, user: user, status: "draft") }
+
+    context "ログインしている場合" do
+      before do
+        get "/api/v1/bugs", headers: headers
+      end
+
+      it "ステータスコード200が返る" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "公開されているバグのリストが返る" do
+        json = JSON.parse(response.body)
+        expect(json["bugs"].size).to eq(10)
+        expect(json["bugs"].pluck("id").sort).to eq(bugs.last(10).pluck(:id).sort)
+      end
+
+      it "未公開のバグは含まれない" do
+        json = JSON.parse(response.body)
+        expect(json["bugs"].pluck("id")).not_to include(unpublished_bug.id.to_s)
+      end
+
+      it "レスポンスにページネーションのメタデータが含まれる" do
+        json = JSON.parse(response.body)
+        expect(json["meta"]["total_pages"]).to eq(3)
+        expect(json["meta"]["current_page"]).to eq(1)
+      end
+    end
+
+    context "ログインしていない場合" do
+      before do
+        get "/api/v1/bugs"
+      end
+
+      it "ステータスコード200が返る" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "公開されているバグのリストが返る" do
+        json = JSON.parse(response.body)
+        expect(json["bugs"].size).to eq(10)
+        expect(json["bugs"].pluck("id").sort).to eq(bugs.last(10).pluck(:id).sort)
+      end
+
+      it "未公開のバグは含まれない" do
+        json = JSON.parse(response.body)
+        expect(json["bugs"].pluck("id")).not_to include(unpublished_bug.id.to_s)
+      end
+
+      it "レスポンスにページネーションのメタデータが含まれる" do
+        json = JSON.parse(response.body)
+        expect(json["meta"]["total_pages"]).to eq(3)
+        expect(json["meta"]["current_page"]).to eq(1)
+      end
+    end
+  end
+
   describe "POST /api/v1/bugs" do
-    let!(:user) { create(:user) }
-    let(:headers) { user.create_new_auth_token }
     let(:valid_params) do
       {
         title: "Example Bug Title",

--- a/backend/spec/requests/api/v1/bugs_spec.rb
+++ b/backend/spec/requests/api/v1/bugs_spec.rb
@@ -5,33 +5,87 @@ RSpec.describe "Api::V1::Bug", type: :request do
   let(:headers) { user.create_new_auth_token }
 
   describe "GET /api/v1/bugs" do
-    let!(:bugs) { create_list(:bug, 30, user: user, status: "published") }
+    let!(:bugs) { create_list(:bug, 25, user: user, status: "published") }
     let!(:unpublished_bug) { create(:bug, user: user, status: "draft") }
 
     context "ログインしている場合" do
       before do
-        get "/api/v1/bugs", headers: headers
+        get "/api/v1/bugs", headers: headers, params: { page: page }
       end
 
-      it "ステータスコード200が返る" do
-        expect(response).to have_http_status(:ok)
+      context "1ページ目" do
+        let(:page) { 1 }
+
+        it "ステータスコード200が返る" do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "公開されているバグのリストが返る" do
+          json = JSON.parse(response.body)
+          expect(json["bugs"].size).to eq(10)
+          expect(json["bugs"].pluck("id")).to eq(bugs.sort_by(&:created_at).reverse.first(10).pluck(:id))
+        end
+
+        it "未公開のバグは含まれない" do
+          json = JSON.parse(response.body)
+          expect(json["bugs"].pluck("id")).not_to include(unpublished_bug.id.to_s)
+        end
+
+        it "レスポンスにページネーションのメタデータが含まれる" do
+          json = JSON.parse(response.body)
+          expect(json["meta"]["total_pages"]).to eq(3)
+          expect(json["meta"]["current_page"]).to eq(1)
+        end
       end
 
-      it "公開されているバグのリストが返る" do
-        json = JSON.parse(response.body)
-        expect(json["bugs"].size).to eq(10)
-        expect(json["bugs"].pluck("id").sort).to eq(bugs.last(10).pluck(:id).sort)
+      context "2ページ目" do
+        let(:page) { 2 }
+
+        it "ステータスコード200が返る" do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "公開されているバグのリストが返る" do
+          json = JSON.parse(response.body)
+          expect(json["bugs"].size).to eq(10)
+          expect(json["bugs"].pluck("id")).to eq(bugs.sort_by(&:created_at).reverse[10..19].pluck(:id))
+        end
+
+        it "未公開のバグは含まれない" do
+          json = JSON.parse(response.body)
+          expect(json["bugs"].pluck("id")).not_to include(unpublished_bug.id.to_s)
+        end
+
+        it "レスポンスにページネーションのメタデータが含まれる" do
+          json = JSON.parse(response.body)
+          expect(json["meta"]["total_pages"]).to eq(3)
+          expect(json["meta"]["current_page"]).to eq(2)
+        end
       end
 
-      it "未公開のバグは含まれない" do
-        json = JSON.parse(response.body)
-        expect(json["bugs"].pluck("id")).not_to include(unpublished_bug.id.to_s)
-      end
+      context "3ページ目" do
+        let(:page) { 3 }
 
-      it "レスポンスにページネーションのメタデータが含まれる" do
-        json = JSON.parse(response.body)
-        expect(json["meta"]["total_pages"]).to eq(3)
-        expect(json["meta"]["current_page"]).to eq(1)
+        it "ステータスコード200が返る" do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "公開されているバグのリストが返る" do
+          json = JSON.parse(response.body)
+          expect(json["bugs"].size).to eq(5)
+          expect(json["bugs"].pluck("id")).to eq(bugs.sort_by(&:created_at).reverse[20..24].pluck(:id))
+        end
+
+        it "未公開のバグは含まれない" do
+          json = JSON.parse(response.body)
+          expect(json["bugs"].pluck("id")).not_to include(unpublished_bug.id.to_s)
+        end
+
+        it "レスポンスにページネーションのメタデータが含まれる" do
+          json = JSON.parse(response.body)
+          expect(json["meta"]["total_pages"]).to eq(3)
+          expect(json["meta"]["current_page"]).to eq(3)
+        end
       end
     end
 
@@ -47,7 +101,7 @@ RSpec.describe "Api::V1::Bug", type: :request do
       it "公開されているバグのリストが返る" do
         json = JSON.parse(response.body)
         expect(json["bugs"].size).to eq(10)
-        expect(json["bugs"].pluck("id").sort).to eq(bugs.last(10).pluck(:id).sort)
+        expect(json["bugs"].pluck("id")).to eq(bugs.sort_by(&:created_at).reverse.first(10).pluck(:id))
       end
 
       it "未公開のバグは含まれない" do

--- a/frontend/src/components/layouts/Header.tsx
+++ b/frontend/src/components/layouts/Header.tsx
@@ -7,7 +7,9 @@ export const Header = () => {
   return (
     <div className="navbar bg-base-100">
       <div className="flex-1">
-        <a className="btn btn-ghost text-xl">daisyUI</a>
+        <Link href="/bugs" className="btn btn-ghost text-xl">
+          Bug Note
+        </Link>
       </div>
       <div className="flex-none">
         {isFetched && (

--- a/frontend/src/components/utilities/NoData.tsx
+++ b/frontend/src/components/utilities/NoData.tsx
@@ -1,0 +1,5 @@
+export const NoData = () => (
+  <div className="p-4 text-center pt-32">
+    <p className="text-lg font-semibold text-gray-600">データがありません</p>
+  </div>
+)

--- a/frontend/src/components/utilities/NoData.tsx
+++ b/frontend/src/components/utilities/NoData.tsx
@@ -1,5 +1,5 @@
 export const NoData = () => (
-  <div className="p-4 text-center pt-32">
+  <div className="p-4 pt-32 text-center">
     <p className="text-lg font-semibold text-gray-600">データがありません</p>
   </div>
 )

--- a/frontend/src/components/utilities/Pagination.tsx
+++ b/frontend/src/components/utilities/Pagination.tsx
@@ -1,0 +1,86 @@
+type PaginationProps = {
+  currentPage: number
+  totalPages: number
+  onChange: (page: number) => void
+}
+
+export const Pagination = ({
+  currentPage,
+  totalPages,
+  onChange,
+}: PaginationProps) => {
+  const getPageNumbers = () => {
+    const pages: (number | '...')[] = []
+    const maxVisiblePages = 5
+
+    if (totalPages <= maxVisiblePages) {
+      return Array.from({ length: totalPages }, (_, i) => i + 1)
+    }
+
+    if (currentPage <= 3) {
+      pages.push(1, 2, 3, '...', totalPages)
+    } else if (currentPage >= totalPages - 2) {
+      pages.push(1, '...', totalPages - 2, totalPages - 1, totalPages)
+    } else {
+      pages.push(
+        1,
+        '...',
+        currentPage - 1,
+        currentPage,
+        currentPage + 1,
+        '...',
+        totalPages,
+      )
+    }
+
+    return pages
+  }
+
+  return (
+    <div className="flex space-x-2">
+      <button
+        className="btn btn-circle"
+        onClick={() => onChange(1)}
+        disabled={currentPage === 1}
+      >
+        «
+      </button>
+      <button
+        className="btn btn-circle"
+        onClick={() => onChange(currentPage - 1)}
+        disabled={currentPage === 1}
+      >
+        ‹
+      </button>
+      {getPageNumbers().map((page, index) =>
+        page === '...' ? (
+          <span key={index} className="btn btn-disabled btn-circle">
+            ...
+          </span>
+        ) : (
+          <button
+            key={index}
+            className={`btn btn-circle ${page === currentPage ? 'btn-primary' : 'btn-ghost'}`}
+            onClick={() => onChange(page)}
+          >
+            {page}
+          </button>
+        ),
+      )}
+      <button
+        className="btn btn-circle"
+        onClick={() => onChange(currentPage + 1)}
+        disabled={currentPage === totalPages}
+      >
+        ›
+      </button>
+      <button
+        className="btn btn-circle"
+        onClick={() => onChange(totalPages)}
+        disabled={currentPage === totalPages}
+      >
+        »
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/features/bugs/components/BugList.tsx
+++ b/frontend/src/features/bugs/components/BugList.tsx
@@ -1,0 +1,14 @@
+import { BugListItem as BugListItemType } from '../types/BugListItem'
+import { BugListItem } from '../ui/BugListItem'
+
+type BugListProps = {
+  bugs: BugListItemType[]
+}
+
+export const BugList = ({ bugs }: BugListProps) => {
+  return (
+    <div className="space-y-4">
+      {bugs?.map((bug) => <BugListItem key={bug.id} {...bug} />)}
+    </div>
+  )
+}

--- a/frontend/src/features/bugs/types/Bug.ts
+++ b/frontend/src/features/bugs/types/Bug.ts
@@ -14,8 +14,13 @@ export type Bug = {
   solution: string
   references: Reference[]
   etc: string
-  status: 'draft' | 'public'
+  status: 'draft' | 'published'
   isSolved: boolean
   createdAt: string
   updatedAt: string
+  user: {
+    image: string
+    name: string
+    nickname: string
+  }
 }

--- a/frontend/src/features/bugs/types/BugListItem.tsx
+++ b/frontend/src/features/bugs/types/BugListItem.tsx
@@ -1,0 +1,9 @@
+export type BugListItem = {
+  id: number
+  title: string
+  createdAt: string
+  user: {
+    nickname: string
+    image: string
+  }
+}

--- a/frontend/src/features/bugs/ui/BugListItem.tsx
+++ b/frontend/src/features/bugs/ui/BugListItem.tsx
@@ -1,0 +1,22 @@
+import { BugListItem as BugListItemType } from '../types/BugListItem'
+
+type BugListItemProps = Omit<BugListItemType, 'id'>
+
+export const BugListItem = ({ title, createdAt, user }: BugListItemProps) => {
+  return (
+    <div className="card w-full bg-base-100 shadow-xl">
+      <div className="card-body">
+        <h3 className="card-title text-xl font-semibold">{title}</h3>
+        <p className="text-sm text-gray-600">投稿日: {createdAt}</p>
+        <div className="mt-4 flex items-center gap-4">
+          <div className="avatar">
+            <div className="size-12 rounded-full">
+              {/* <img src={user.image} alt={user.nickname} /> */}
+            </div>
+          </div>
+          <p className="font-medium">{user.nickname}</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/bugs/validations/saveBugValidations.ts
+++ b/frontend/src/features/bugs/validations/saveBugValidations.ts
@@ -40,7 +40,7 @@ export const bugSchema = z
     ),
     etc: z.string().optional(),
     is_solved: z.boolean(),
-    status: z.enum(['draft', 'public']).optional(),
+    status: z.enum(['draft', 'published']).optional(),
   })
   .refine(
     (data) => {
@@ -55,7 +55,7 @@ export const bugSchema = z
   )
   .refine(
     (data) => {
-      return data.is_solved || data.status !== 'public'
+      return data.is_solved || data.status !== 'published'
     },
     {
       message: '未解決の場合公開できません',

--- a/frontend/src/pages/bugs/index.tsx
+++ b/frontend/src/pages/bugs/index.tsx
@@ -1,0 +1,52 @@
+import { useQuery } from '@tanstack/react-query'
+import { useRouter } from 'next/router'
+import { Layout } from '@/components/Layout'
+import { Loading } from '@/components/utilities/Loading'
+import { NoData } from '@/components/utilities/NoData'
+import { Pagination } from '@/components/utilities/Pagination'
+import { BugList } from '@/features/bugs/components/BugList'
+import { BugListItem } from '@/features/bugs/types/BugListItem'
+import { fetcher } from '@/utils'
+import { API_URLS } from '@/utils/api'
+
+type meta = {
+  totalPages: number
+  currentPage: number
+}
+
+const BugListPage = () => {
+  const router = useRouter()
+  const page = 'page' in router.query ? Number(router.query.page) : 1
+
+  const { data, isPending } = useQuery<{ bugs: BugListItem[]; meta: meta }>({
+    queryKey: ['bugs'],
+    queryFn: () => fetcher(`${API_URLS.BUG.INDEX}?page=${page}`),
+  })
+
+  const handleChangePage = (page: number) => {
+    router.push('bugs?page=' + page)
+  }
+
+  return (
+    <Layout>
+      {isPending ? (
+        <Loading />
+      ) : data?.bugs && data.bugs?.length > 0 ? (
+        <div className="mx-auto my-12 w-full max-w-full p-4 md:max-w-4xl lg:max-w-3xl">
+          <BugList bugs={data.bugs} />
+          <div className="flex justify-center py-6">
+            <Pagination
+              totalPages={data.meta.totalPages}
+              currentPage={data.meta.currentPage}
+              onChange={handleChangePage}
+            />
+          </div>
+        </div>
+      ) : (
+        <NoData />
+      )}
+    </Layout>
+  )
+}
+
+export default BugListPage

--- a/frontend/src/pages/bugs/new.tsx
+++ b/frontend/src/pages/bugs/new.tsx
@@ -25,6 +25,7 @@ import {
   bugSchema,
 } from '@/features/bugs/validations/saveBugValidations'
 import { useRequiredSignedIn } from '@/hooks/useRequiredSignedIn'
+import { fetcher } from '@/utils'
 import { API_URLS } from '@/utils/api'
 import { getAuthHeaders } from '@/utils/headers'
 
@@ -82,14 +83,9 @@ export default function BugFormContainer() {
     name: 'references',
   })
 
-  const fetchCategories = async () => {
-    const res = await axios.get(API_URLS.CATEGORIES)
-    return res.data
-  }
-
   const { data: categories } = useQuery<Category[]>({
     queryKey: ['categories'],
-    queryFn: fetchCategories,
+    queryFn: () => fetcher(API_URLS.CATEGORIES),
   })
 
   const handleChangeCategory = (index: number, value: string) => {
@@ -128,14 +124,14 @@ export default function BugFormContainer() {
           <div className="flex flex-col items-center">
             <input
               type="checkbox"
-              checked={status === 'public'}
+              checked={status === 'published'}
               onChange={() =>
-                setValue('status', status === 'draft' ? 'public' : 'draft')
+                setValue('status', status === 'draft' ? 'published' : 'draft')
               }
               className="toggle toggle-lg"
             />
             <span className="mt-1 text-sm">
-              {status === 'public' ? '公開' : '下書き'}
+              {status === 'published' ? '公開' : '下書き'}
             </span>
           </div>
 

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -6,6 +6,7 @@ export const API_URLS = {
     CURRENT_USER: `${process.env.NEXT_PUBLIC_API_URL}/current/user`,
   },
   BUG: {
+    INDEX: `${process.env.NEXT_PUBLIC_API_URL}/bugs`,
     CREATE: `${process.env.NEXT_PUBLIC_API_URL}/bugs`,
   },
   CATEGORIES: `${process.env.NEXT_PUBLIC_API_URL}/categories`,


### PR DESCRIPTION
## 概要

## 関連するissue番号

- #15 

## 行ったこと

- statusのpublicをpublishedに変更
- バグ一覧API作成
- バグ一覧のリクエストスペック作成
- バグ一覧で汎用的に使うコンポーネント作成
- バグ一覧ページコンポーネント作成

## 動作確認

フロントエンド http://localhost:8080/bugs
バックエンド http://localhost:3100/api/v1/bugs

## その他

バグ一覧のユーザーの画像がコメントの状態
リクエストスペックでページネーションのテスト未実装
フロントのテストを未実装

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Exposed a bug listing endpoint that now supports pagination and enables unauthenticated users to view published bugs.
  - Introduced new UI components including a structured bug list, pagination controls, and a fallback display for no available data.
  - Updated header navigation for improved routing.

- **Refactor**
  - Revised status terminology from "public" to "published" for consistency.
  - Enhanced authentication logic and streamlined category fetching on the bug submission page.

- **Tests**
  - Expanded test coverage to ensure correct pagination and visibility of published bugs for all user scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->