### PR TITLE
マイページ実装

### DIFF
--- a/backend/app/controllers/api/v1/mypage/bugs_controller.rb
+++ b/backend/app/controllers/api/v1/mypage/bugs_controller.rb
@@ -1,0 +1,36 @@
+class Api::V1::Mypage::BugsController < Api::V1::BaseController
+  include Pagination
+
+  before_action :authenticate_user!
+
+  def index
+    render_bugs
+  end
+
+  def solved
+    render_bugs(is_solved: true)
+  end
+
+  def unsolved
+    render_bugs(is_solved: false)
+  end
+
+  def published
+    render_bugs(status: "published")
+  end
+
+  def draft
+    render_bugs(status: "draft")
+  end
+
+  private
+
+    def render_bugs(filters = {})
+      bugs = current_user.bugs.where(filters).
+               includes(:user, :environments, :attempts, :references).
+               order(created_at: :desc).
+               page(params[:page] || 1).
+               per(10)
+      render json: bugs, each_serializer: BugSerializer, status: :ok, meta: pagination(bugs), adapter: :json
+    end
+end

--- a/backend/app/controllers/concerns/pagination.rb
+++ b/backend/app/controllers/concerns/pagination.rb
@@ -5,6 +5,7 @@ module Pagination
     {
       current_page: records.current_page,
       total_pages: records.total_pages,
+      total_count: records.total_count,
     }
   end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -11,6 +11,16 @@ Rails.application.routes.draw do
       end
       resources :categories, only: [:index]
       resources :bugs, only: [:index, :show, :create, :update, :destroy]
+      namespace :mypage do
+        resources :bugs, only: [:index] do
+          collection do
+            get "solved", to: "bugs#solved"
+            get "unsolved", to: "bugs#unsolved"
+            get "published", to: "bugs#published"
+            get "draft", to: "bugs#draft"
+          end
+        end
+      end
     end
   end
 

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -23,7 +23,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
+Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -33,11 +33,6 @@ rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
 RSpec.configure do |config|
-  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_paths = [
-    Rails.root.join('spec/fixtures')
-  ]
-
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.

--- a/backend/spec/requests/api/v1/bugs_spec.rb
+++ b/backend/spec/requests/api/v1/bugs_spec.rb
@@ -1,9 +1,5 @@
 require "rails_helper"
 
-def response_json
-  JSON.parse(response.body)
-end
-
 RSpec.describe "Api::V1::Bug", type: :request do
   let!(:user) { create(:user) }
   let(:other_user) { create(:user) }

--- a/backend/spec/requests/api/v1/bugs_spec.rb
+++ b/backend/spec/requests/api/v1/bugs_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Api::V1::Bug", type: :request do
-  let!(:user) { create(:user) }
+  let(:user) { create(:user) }
   let(:other_user) { create(:user) }
   let(:headers) { user.create_new_auth_token }
 

--- a/backend/spec/requests/api/v1/mypage/bugs_spec.rb
+++ b/backend/spec/requests/api/v1/mypage/bugs_spec.rb
@@ -1,0 +1,119 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Mypage::Bugs", type: :request do
+  let(:user) { create(:user) }
+  let(:headers) { user.create_new_auth_token }
+
+  describe "GET /mypage/bugs" do
+    let!(:bugs) { create_list(:bug, 5, user: user) }
+
+    context "ログインしている場合" do
+      it "認証ユーザーのバグ一覧を取得できる" do
+        get api_v1_mypage_bugs_path, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response_json["bugs"].size).to eq(5)
+      end
+    end
+
+    context "ログインしていない場合" do
+      it "認証エラーが発生すること" do
+        get api_v1_mypage_bugs_path
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "GET /mypage/bugs/solved" do
+    let!(:solved_bug) { create(:bug, user: user, is_solved: true) }
+    let!(:unsolved_bug) { create(:bug, user: user, is_solved: false) }
+
+    context "ログインしている場合" do
+      it "解決済みのバグのみを取得できる" do
+        get solved_api_v1_mypage_bugs_path, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response_json["bugs"].size).to eq(1)
+        expect(response_json["bugs"].first["is_solved"]).to be(true)
+      end
+    end
+
+    context "ログインしていない場合" do
+      it "認証エラーが発生すること" do
+        get solved_api_v1_mypage_bugs_path
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "GET /mypage/bugs/unsolved" do
+    let!(:solved_bug) { create(:bug, user: user, is_solved: true) }
+    let!(:unsolved_bug) { create(:bug, user: user, is_solved: false) }
+
+    context "ログインしている場合" do
+      it "未解決のバグのみを取得できる" do
+        get unsolved_api_v1_mypage_bugs_path, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response_json["bugs"].size).to eq(1)
+        expect(response_json["bugs"].first["is_solved"]).to be(false)
+      end
+    end
+
+    context "ログインしていない場合" do
+      it "認証エラーが発生すること" do
+        get unsolved_api_v1_mypage_bugs_path
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "GET /mypage/bugs/published" do
+    let!(:published_bug) { create(:bug, user: user, status: "published") }
+    let!(:draft_bug) { create(:bug, user: user, status: "draft") }
+
+    context "ログインしている場合" do
+      it "公開済みのバグのみを取得できる" do
+        get published_api_v1_mypage_bugs_path, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response_json["bugs"].size).to eq(1)
+        expect(response_json["bugs"].first["status"]).to eq("published")
+      end
+    end
+
+    context "ログインしていない場合" do
+      it "認証エラーが発生すること" do
+        get published_api_v1_mypage_bugs_path
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "GET /mypage/bugs/draft" do
+    let!(:published_bug) { create(:bug, user: user, status: "published") }
+    let!(:draft_bug) { create(:bug, user: user, status: "draft") }
+
+    context "ログインしている場合" do
+      it "下書きのバグのみを取得できる" do
+        get draft_api_v1_mypage_bugs_path, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response_json["bugs"].size).to eq(1)
+        expect(response_json["bugs"].first["status"]).to eq("draft")
+      end
+    end
+
+    context "ログインしていない場合" do
+      it "認証エラーが発生すること" do
+        get draft_api_v1_mypage_bugs_path
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/backend/spec/support/api_helper.rb
+++ b/backend/spec/support/api_helper.rb
@@ -1,0 +1,9 @@
+module ApiHelper
+  def response_json
+  JSON.parse(response.body)
+  end
+end
+
+RSpec.configure do |config|
+  config.include ApiHelper, type: :request
+end

--- a/backend/spec/support/api_helper.rb
+++ b/backend/spec/support/api_helper.rb
@@ -1,6 +1,6 @@
 module ApiHelper
   def response_json
-  JSON.parse(response.body)
+    JSON.parse(response.body)
   end
 end
 

--- a/frontend/src/__tests__/components/layouts/Header.test.tsx
+++ b/frontend/src/__tests__/components/layouts/Header.test.tsx
@@ -32,7 +32,7 @@ describe('Header', () => {
     expect(screen.getByText('ログイン')).toBeInTheDocument()
   })
 
-  it('認証済みの場合、ユーザーのプロフィールとログアウトが表示されること', () => {
+  it('認証済みの場合、ユーザーのマイページとログアウトが表示されること', () => {
     ;(useAuth as jest.Mock).mockReturnValue({
       isFetched: true,
       isAuthenticated: true,
@@ -54,7 +54,7 @@ describe('Header', () => {
       </AuthContext.Provider>,
     )
 
-    expect(screen.getByText('プロフィール')).toBeInTheDocument()
+    expect(screen.getByText('マイページ')).toBeInTheDocument()
     expect(screen.getByText('設定')).toBeInTheDocument()
     expect(screen.getByText('ログアウト')).toBeInTheDocument()
   })

--- a/frontend/src/components/MypageLayout.tsx
+++ b/frontend/src/components/MypageLayout.tsx
@@ -1,0 +1,43 @@
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import { ReactNode } from 'react'
+import { Footer } from './layouts/Footer'
+import { Header } from './layouts/Header'
+
+export const MypageLayout = ({ children }: { children: ReactNode }) => {
+  const router = useRouter()
+
+  const isActive = (path: string) => router.pathname === path
+
+  return (
+    <div className="flex min-h-screen flex-col bg-base-200">
+      <Header />
+      <div className="flex flex-1 p-6">
+        <div className="w-64 rounded-md bg-white p-4 shadow-lg">
+          <ul className="menu p-2 font-bold">
+            <li className={isActive('/mypage') ? 'text-primary' : ''}>
+              <Link href="/mypage">バグ</Link>
+            </li>
+            <li className={isActive('/mypage/profile') ? 'text-primary' : ''}>
+              <Link href="">プロフィール</Link>
+            </li>
+            <li className={isActive('/mypage/pass') ? 'text-primary' : ''}>
+              <Link href="">パスワード変更</Link>
+            </li>
+            <li className={isActive('/mypage/email') ? 'text-primary' : ''}>
+              <Link href="">メールアドレス変更</Link>
+            </li>
+            <li className={isActive('/mypage/account') ? 'text-primary' : ''}>
+              <Link href="">アカウント削除</Link>
+            </li>
+          </ul>
+        </div>
+
+        <main className="mx-auto flex-1 p-4 md:max-w-4xl lg:max-w-3xl">
+          {children}
+        </main>
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/frontend/src/components/layouts/Header.tsx
+++ b/frontend/src/components/layouts/Header.tsx
@@ -5,7 +5,7 @@ import { useAuth } from '@/hooks/useAuth'
 export const Header = () => {
   const { isFetched, isAuthenticated, signout } = useAuth()
   return (
-    <div className="navbar bg-base-100">
+    <div className="navbar bg-base-100 shadow-xl">
       <div className="flex-1">
         <Link href="/bugs" className="btn btn-ghost text-xl">
           Bug Note
@@ -18,7 +18,7 @@ export const Header = () => {
               <>
                 <Link href="/bugs/new">
                   <button className="btn btn-circle btn-ghost">
-                    <FaPen className="text-xl" />
+                    <FaPen className="text-xl text-primary" />
                   </button>
                 </Link>
                 <div className="dropdown dropdown-end">
@@ -34,7 +34,9 @@ export const Header = () => {
                     className="menu dropdown-content rounded-box menu-sm z-[1] mt-3 w-52 bg-base-100 p-2 shadow"
                   >
                     <li>
-                      <a className="justify-between">プロフィール</a>
+                      <Link href="/mypage" className="justify-between">
+                        マイページ
+                      </Link>
                     </li>
                     <li>
                       <a>設定</a>

--- a/frontend/src/components/utilities/Loading.tsx
+++ b/frontend/src/components/utilities/Loading.tsx
@@ -4,7 +4,7 @@ type LoadingProps = {
 
 export const Loading = ({ message }: LoadingProps) => {
   return (
-    <div className="fixed inset-0 flex flex-col items-center justify-center bg-white/80 backdrop-blur-sm">
+    <div className="relative flex min-h-screen items-center justify-center bg-white/80 backdrop-blur-sm">
       <span className="loading loading-spinner loading-lg text-purple-500"></span>
       {message && (
         <p className="mt-4 text-lg font-semibold text-gray-700">{message}</p>

--- a/frontend/src/components/utilities/Pagination.tsx
+++ b/frontend/src/components/utilities/Pagination.tsx
@@ -38,20 +38,19 @@ export const Pagination = ({
 
   return (
     <div className="flex space-x-2">
-      <button
-        className="btn btn-circle"
-        onClick={() => onChange(1)}
-        disabled={currentPage === 1}
-      >
-        «
-      </button>
-      <button
-        className="btn btn-circle"
-        onClick={() => onChange(currentPage - 1)}
-        disabled={currentPage === 1}
-      >
-        ‹
-      </button>
+      {currentPage > 1 && (
+        <button className="btn btn-circle" onClick={() => onChange(1)}>
+          «
+        </button>
+      )}
+      {currentPage > 1 && (
+        <button
+          className="btn btn-circle"
+          onClick={() => onChange(currentPage - 1)}
+        >
+          ‹
+        </button>
+      )}
       {getPageNumbers().map((page, index) =>
         page === '...' ? (
           <span key={index} className="btn btn-disabled btn-circle">
@@ -67,20 +66,19 @@ export const Pagination = ({
           </button>
         ),
       )}
-      <button
-        className="btn btn-circle"
-        onClick={() => onChange(currentPage + 1)}
-        disabled={currentPage === totalPages}
-      >
-        ›
-      </button>
-      <button
-        className="btn btn-circle"
-        onClick={() => onChange(totalPages)}
-        disabled={currentPage === totalPages}
-      >
-        »
-      </button>
+      {currentPage < totalPages && (
+        <button
+          className="btn btn-circle"
+          onClick={() => onChange(currentPage + 1)}
+        >
+          ›
+        </button>
+      )}
+      {currentPage < totalPages && (
+        <button className="btn btn-circle" onClick={() => onChange(totalPages)}>
+          »
+        </button>
+      )}
     </div>
   )
 }

--- a/frontend/src/features/bugs/types/BugListItem.tsx
+++ b/frontend/src/features/bugs/types/BugListItem.tsx
@@ -1,6 +1,8 @@
 export type BugListItem = {
   id: number
   title: string
+  isSolved: boolean
+  status: 'draft' | 'published'
   createdAt: string
   user: {
     nickname: string

--- a/frontend/src/features/bugs/ui/BugListItem.tsx
+++ b/frontend/src/features/bugs/ui/BugListItem.tsx
@@ -4,13 +4,31 @@ import { BugListItem as BugListItemType } from '../types/BugListItem'
 export const BugListItem = ({
   id,
   title,
+  isSolved,
+  status,
   createdAt,
   user,
 }: BugListItemType) => {
   return (
     <Link href={`/bugs/${id}`} className="block">
-      <div className="card w-full bg-base-100 shadow-xl">
-        <div className="card-body">
+      <div className="card relative w-full bg-base-100 shadow-xl">
+        <div className="absolute right-8 top-4 flex gap-2">
+          <div
+            className={`w-16 px-3 py-1 text-center text-xs font-semibold text-white 
+      ${isSolved ? 'bg-green-500' : 'bg-red-500'}`}
+          >
+            {isSolved ? '解決済' : '未解決'}
+          </div>
+
+          <div
+            className={`w-16 px-3 py-1 text-center text-xs font-semibold text-white 
+      ${status === 'published' ? 'bg-blue-500' : 'bg-gray-500'}`}
+          >
+            {status === 'published' ? '公開' : '下書き'}
+          </div>
+        </div>
+
+        <div className="card-body mt-4">
           <h3 className="card-title text-xl font-semibold">{title}</h3>
           <p className="text-sm text-gray-600">投稿日: {createdAt}</p>
           <div className="mt-4 flex items-center gap-4">

--- a/frontend/src/features/mypage/types/Tab.ts
+++ b/frontend/src/features/mypage/types/Tab.ts
@@ -1,0 +1,6 @@
+import { TabValue } from './TabValue'
+
+export type Tab = {
+  label: string
+  value: TabValue
+}

--- a/frontend/src/features/mypage/types/TabValue.ts
+++ b/frontend/src/features/mypage/types/TabValue.ts
@@ -1,0 +1,1 @@
+export type TabValue = 'all' | 'unsolved' | 'solved' | 'draft' | 'published'

--- a/frontend/src/features/mypage/ui/Tabs.tsx
+++ b/frontend/src/features/mypage/ui/Tabs.tsx
@@ -1,0 +1,27 @@
+import { Tab } from '../types/Tab'
+import { TabValue } from '../types/TabValue'
+
+type TabsProps = {
+  tabs: Tab[]
+  selectedTab: TabValue
+  onClick: (tabValue: TabValue) => void
+}
+
+export const Tabs = ({ tabs, selectedTab, onClick }: TabsProps) => {
+  return (
+    <div>
+      <div role="tablist" className="tabs">
+        {tabs.map((tab) => (
+          <a
+            key={tab.value}
+            role="tab"
+            className={`tab font-bold ${selectedTab === tab.value ? 'tab-active text-primary' : ''}`}
+            onClick={() => onClick(tab.value)}
+          >
+            {tab.label}
+          </a>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/bugs/index.tsx
+++ b/frontend/src/pages/bugs/index.tsx
@@ -6,21 +6,17 @@ import { NoData } from '@/components/utilities/NoData'
 import { Pagination } from '@/components/utilities/Pagination'
 import { BugList } from '@/features/bugs/components/BugList'
 import { BugListItem } from '@/features/bugs/types/BugListItem'
+import { Meta } from '@/types/Meta'
 import { fetcher } from '@/utils'
 import { API_URLS } from '@/utils/api'
-
-type meta = {
-  totalPages: number
-  currentPage: number
-}
 
 const BugListPage = () => {
   const router = useRouter()
   const page = 'page' in router.query ? Number(router.query.page) : 1
 
-  const { data, isPending } = useQuery<{ bugs: BugListItem[]; meta: meta }>({
-    queryKey: ['bugs'],
-    queryFn: () => fetcher(`${API_URLS.BUG.INDEX}?page=${page}`),
+  const { data, isPending } = useQuery<{ bugs: BugListItem[]; meta: Meta }>({
+    queryKey: ['bugs', page],
+    queryFn: () => fetcher(API_URLS.BUG.INDEX(page)),
   })
 
   const handleChangePage = (page: number) => {

--- a/frontend/src/pages/mypage/index.tsx
+++ b/frontend/src/pages/mypage/index.tsx
@@ -1,0 +1,96 @@
+import { useQuery } from '@tanstack/react-query'
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import { MypageLayout } from '@/components/MypageLayout'
+import { Loading } from '@/components/utilities/Loading'
+import { NoData } from '@/components/utilities/NoData'
+import { Pagination } from '@/components/utilities/Pagination'
+import { BugList } from '@/features/bugs/components/BugList'
+import { BugListItem } from '@/features/bugs/types/BugListItem'
+import { Tab } from '@/features/mypage/types/Tab'
+import { TabValue } from '@/features/mypage/types/TabValue'
+import { Tabs } from '@/features/mypage/ui/Tabs'
+import { useRequiredSignedIn } from '@/hooks/useRequiredSignedIn'
+import { Meta } from '@/types/Meta'
+import { fetcher } from '@/utils'
+import { API_URLS } from '@/utils/api'
+
+const tabs: Tab[] = [
+  {
+    label: `全て`,
+    value: 'all',
+  },
+  {
+    label: '未解決',
+    value: 'unsolved',
+  },
+  {
+    label: '解決済',
+    value: 'solved',
+  },
+  {
+    label: '下書き',
+    value: 'draft',
+  },
+  {
+    label: '公開',
+    value: 'published',
+  },
+]
+
+const Mypage = () => {
+  useRequiredSignedIn()
+  const router = useRouter()
+  const page = 'page' in router.query ? Number(router.query.page) : 1
+  const [selectedTab, setSelectedTab] = useState<TabValue>('all')
+
+  const { data, isPending, isFetching } = useQuery<{
+    bugs: BugListItem[]
+    meta: Meta
+  }>({
+    queryKey: ['bugs', selectedTab, page],
+    queryFn: () => fetcher(API_URLS.MYPAGE.BUG(selectedTab, page)),
+  })
+
+  const handleChangePage = (page: number) => {
+    router.push(`/mypage?page=${page}`)
+  }
+
+  useEffect(() => {
+    router.push(`/mypage?page=1`, undefined, {
+      shallow: true,
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedTab])
+
+  return (
+    <MypageLayout>
+      <div className="mt-8 flex justify-center">
+        <Tabs tabs={tabs} selectedTab={selectedTab} onClick={setSelectedTab} />
+      </div>
+
+      <div className="mt-4 text-right font-bold text-gray-600">
+        <span className="text-2xl">{data?.bugs?.length}</span>件 /{' '}
+        <span className="text-2xl">{data?.meta?.totalCount}</span>件
+      </div>
+
+      {isPending || isFetching ? (
+        <Loading />
+      ) : data?.bugs?.length ? (
+        <div className="mt-8">
+          <BugList bugs={data.bugs} />
+          <div className="flex justify-center py-10">
+            <Pagination
+              totalPages={data.meta.totalPages}
+              currentPage={data.meta.currentPage}
+              onChange={handleChangePage}
+            />
+          </div>
+        </div>
+      ) : (
+        <NoData />
+      )}
+    </MypageLayout>
+  )
+}
+export default Mypage

--- a/frontend/src/types/Meta.ts
+++ b/frontend/src/types/Meta.ts
@@ -1,0 +1,5 @@
+export type Meta = {
+  totalPages: number
+  currentPage: number
+  totalCount: number
+}

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -6,11 +6,18 @@ export const API_URLS = {
     CURRENT_USER: `${process.env.NEXT_PUBLIC_API_URL}/current/user`,
   },
   BUG: {
-    INDEX: `${process.env.NEXT_PUBLIC_API_URL}/bugs`,
+    INDEX: (page: number) =>
+      `${process.env.NEXT_PUBLIC_API_URL}/bugs?page=${page}`,
     SHOW: (id: string) => `${process.env.NEXT_PUBLIC_API_URL}/bugs/${id}`,
     CREATE: `${process.env.NEXT_PUBLIC_API_URL}/bugs`,
     UPDATE: (id: string) => `${process.env.NEXT_PUBLIC_API_URL}/bugs/${id}`,
     DELETE: (id: string) => `${process.env.NEXT_PUBLIC_API_URL}/bugs/${id}`,
   },
   CATEGORIES: `${process.env.NEXT_PUBLIC_API_URL}/categories`,
+  MYPAGE: {
+    BUG: (filter: string, page: number) => {
+      const filterValue = filter === 'all' ? '' : filter
+      return `${process.env.NEXT_PUBLIC_API_URL}/mypage/bugs${filterValue ? `/${filterValue}` : ''}?page=${page}`
+    },
+  },
 }


### PR DESCRIPTION
## 概要

## 関連するissue番号

- #28 

## 行ったこと

- マイページでのバグ一覧取得API実装
- マイページでのバグ一覧取得のリクエストスペック作成
- マイページのレイアウト作成
- バグ一覧でpageを切り替えるごとに再フェッチを行うように修正
- バグ一覧を切り替えるタブを作成
- マイページのページコンポーネント作成

## 動作確認

フロントエンド http://localhost:8080/mypage
バックエンド http://localhost:3100

## その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a revamped MyPage with enhanced bug filtering options (solved, unsolved, published, draft) and a dedicated layout featuring a sidebar and tab navigation.
  
- **Style & UX Improvements**
  - Updated header labeling for clearer navigation.
  - Refined bug list displays with visual badges indicating resolution and publication status.
  - Improved pagination controls and loading screen behavior for a smoother user experience.

- **Refinements**
  - Enhanced data fetching and pagination details for more responsive interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->