### PR TITLE
バグのいいね一覧実装

### DIFF
--- a/backend/app/controllers/api/v1/base_controller.rb
+++ b/backend/app/controllers/api/v1/base_controller.rb
@@ -1,5 +1,8 @@
 class Api::V1::BaseController < ApplicationController
-  alias_method :current_user, :current_api_v1_user
   alias_method :authenticate_user!, :authenticate_api_v1_user!
   alias_method :user_signed_in?, :api_v1_user_signed_in?
+
+  def current_user
+    @current_user ||= current_api_v1_user
+  end
 end

--- a/backend/app/controllers/api/v1/bugs_controller.rb
+++ b/backend/app/controllers/api/v1/bugs_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::BugsController < Api::V1::BaseController
   before_action :authenticate_user!, only: [:create, :update, :destroy]
 
   def index
-    bugs = Bug.where(status: "published").includes(:user).order(created_at: :desc).page(params[:page] || 1).per(10)
+    bugs = Bug.where(status: "published").includes(:user, :likes).order(created_at: :desc).page(params[:page] || 1).per(10)
     render json: bugs, each_serializer: BugListSerializer, status: :ok, meta: pagination(bugs), adapter: :json
   end
 

--- a/backend/app/controllers/api/v1/mypage/bugs_controller.rb
+++ b/backend/app/controllers/api/v1/mypage/bugs_controller.rb
@@ -23,11 +23,17 @@ class Api::V1::Mypage::BugsController < Api::V1::BaseController
     render_bugs(status: "draft")
   end
 
+  def liked
+    bugs = current_user.liked_bugs.includes(:user, :likes).order("likes.created_at DESC").page(params[:page] || 1).per(10)
+
+    render json: bugs, each_serializer: BugListSerializer, status: :ok, meta: pagination(bugs), adapter: :json
+  end
+
   private
 
     def render_bugs(filters = {})
       bugs = current_user.bugs.where(filters).
-               includes(:user).
+               includes(:likes).
                order(created_at: :desc).
                page(params[:page] || 1).
                per(10)

--- a/backend/app/controllers/api/v1/mypage/bugs_controller.rb
+++ b/backend/app/controllers/api/v1/mypage/bugs_controller.rb
@@ -24,7 +24,7 @@ class Api::V1::Mypage::BugsController < Api::V1::BaseController
   end
 
   def liked
-    bugs = current_user.liked_bugs.includes(:user, :likes).order("likes.created_at DESC").page(params[:page] || 1).per(10)
+    bugs = current_user.liked_bugs.includes(:user).order("likes.created_at DESC").page(params[:page] || 1).per(10)
 
     render json: bugs, each_serializer: BugListSerializer, status: :ok, meta: pagination(bugs), adapter: :json
   end
@@ -33,7 +33,6 @@ class Api::V1::Mypage::BugsController < Api::V1::BaseController
 
     def render_bugs(filters = {})
       bugs = current_user.bugs.where(filters).
-               includes(:likes).
                order(created_at: :desc).
                page(params[:page] || 1).
                per(10)

--- a/backend/app/models/like.rb
+++ b/backend/app/models/like.rb
@@ -1,4 +1,4 @@
 class Like < ApplicationRecord
   belongs_to :user
-  belongs_to :bug
+  belongs_to :bug, counter_cache: true
 end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -14,6 +14,7 @@ class User < ApplicationRecord
   has_many :passive_follows, class_name: "Follow", foreign_key: "followed_id", dependent: :destroy, inverse_of: :following
   has_many :followers, through: :passive_follows, source: :follower
   has_many :likes, dependent: :destroy
+  has_many :liked_bugs, through: :likes, source: :bug
 
   PASSWORD_COMPLEXITY_REGEX = /\A(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,128}\z/
 

--- a/backend/app/serializers/base_bug_serializer.rb
+++ b/backend/app/serializers/base_bug_serializer.rb
@@ -32,12 +32,13 @@ class BaseBugSerializer < ActiveModel::Serializer
   end
 
   def like_count
-    object.likes.count
+    object.likes_count
   end
 
   # rubocop:disable Naming/PredicateName
   def is_liked
-    object.likes.exists?(user_id: current_user.id) if current_user
+    liked_user_ids = object.likes.pluck(:user_id)
+    liked_user_ids.include?(current_user.id) if current_user
   end
   # rubocop:enable Naming/PredicateName
 end

--- a/backend/app/serializers/base_bug_serializer.rb
+++ b/backend/app/serializers/base_bug_serializer.rb
@@ -37,8 +37,7 @@ class BaseBugSerializer < ActiveModel::Serializer
 
   # rubocop:disable Naming/PredicateName
   def is_liked
-    liked_user_ids = object.likes.pluck(:user_id)
-    liked_user_ids.include?(current_user.id) if current_user
+    object.likes.exists?(user_id: current_user.id) if current_user
   end
   # rubocop:enable Naming/PredicateName
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
             get "unsolved", to: "bugs#unsolved"
             get "published", to: "bugs#published"
             get "draft", to: "bugs#draft"
+            get "liked", to: "bugs#liked"
           end
         end
       end

--- a/backend/db/migrate/20250319125118_add_likes_count_to_bugs.rb
+++ b/backend/db/migrate/20250319125118_add_likes_count_to_bugs.rb
@@ -1,0 +1,5 @@
+class AddLikesCountToBugs < ActiveRecord::Migration[7.1]
+  def change
+    add_column :bugs, :likes_count, :integer, default: 0, null: false
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_17_081422) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_19_125118) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -35,6 +35,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_17_081422) do
     t.boolean "is_solved", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "likes_count", default: 0, null: false
     t.index ["user_id"], name: "index_bugs_on_user_id"
   end
 

--- a/backend/spec/factories/like.rb
+++ b/backend/spec/factories/like.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :like do
+    association :user
+    association :bug
+  end
+end

--- a/backend/spec/requests/api/v1/mypage/bugs_spec.rb
+++ b/backend/spec/requests/api/v1/mypage/bugs_spec.rb
@@ -116,4 +116,28 @@ RSpec.describe "Api::V1::Mypage::Bugs", type: :request do
       end
     end
   end
+
+  describe "GET /mypage/bugs/likes" do
+    let!(:other_user) { create(:user) }
+    let!(:liked_bug) { create(:bug, user: other_user, status: "published") }
+    let!(:like) { create(:like, user: user, bug: liked_bug) }
+
+    context "ログインしている場合" do
+      it "いいねしたバグを取得できる" do
+        get liked_api_v1_mypage_bugs_path, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response_json["bugs"].size).to eq(1)
+        expect(response_json["bugs"].first["id"]).to eq(liked_bug.id)
+      end
+    end
+
+    context "ログインしていない場合" do
+      it "認証エラーが発生すること" do
+        get liked_api_v1_mypage_bugs_path
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
 end

--- a/frontend/src/features/mypage/types/TabValue.ts
+++ b/frontend/src/features/mypage/types/TabValue.ts
@@ -1,1 +1,7 @@
-export type TabValue = 'all' | 'unsolved' | 'solved' | 'draft' | 'published'
+export type TabValue =
+  | 'all'
+  | 'unsolved'
+  | 'solved'
+  | 'draft'
+  | 'published'
+  | 'liked'

--- a/frontend/src/pages/mypage/index.tsx
+++ b/frontend/src/pages/mypage/index.tsx
@@ -36,6 +36,10 @@ const tabs: Tab[] = [
     label: '公開',
     value: 'published',
   },
+  {
+    label: 'いいね',
+    value: 'liked',
+  },
 ]
 
 const Mypage = () => {

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -33,12 +33,12 @@ export const API_URLS = {
       DELETE: (id: string) =>
         `${process.env.NEXT_PUBLIC_API_URL}/bugs/${id}/likes`,
     },
-    CATEGORIES: `${process.env.NEXT_PUBLIC_API_URL}/categories`,
-    MYPAGE: {
-      BUG: (filter: string, page: number) => {
-        const filterValue = filter === 'all' ? '' : filter
-        return `${process.env.NEXT_PUBLIC_API_URL}/mypage/bugs${filterValue ? `/${filterValue}` : ''}?page=${page}`
-      },
+  },
+  CATEGORIES: `${process.env.NEXT_PUBLIC_API_URL}/categories`,
+  MYPAGE: {
+    BUG: (filter: string, page: number) => {
+      const filterValue = filter === 'all' ? '' : filter
+      return `${process.env.NEXT_PUBLIC_API_URL}/mypage/bugs${filterValue ? `/${filterValue}` : ''}?page=${page}`
     },
   },
 }


### PR DESCRIPTION
## 概要

## 関連するissue番号

- #28 

## 行ったこと

- バグのいいね一覧API実装
- バグのいいね一覧APIのリクエストスペック作成
- いいね数のカウンターキャッシュのマイグレーションを作成
- いいね一覧でのis_likedとlike_countのN+1問題を対策
- マイページのタブでいいね一覧を追加

## 動作確認

フロントエンド http://localhost:8080/mypage
バックエンド http://localhost:3100/api/v1/mypage/bugs/liked

## その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new "Liked" tab on the My Page, allowing users to view bugs they have endorsed.
	- Introduced an endpoint for retrieving bugs that the current user has liked.

- **Bug Fixes**
	- Improved data retrieval for bugs by including associated likes in the response.

- **Refactor**
	- Enhanced bug listing by incorporating pre-calculated like counts and improved liked status detection for a smoother viewing experience.
	- Updated method for retrieving the current user to improve performance with lazy loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->