### PR TITLE
アカウント削除機能実装

### DIFF
--- a/backend/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/backend/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,0 +1,14 @@
+class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+  include DeviseTokenAuth::Concerns::SetUserByToken
+
+  before_action :authenticate_api_v1_user!, only: [:destroy]
+
+  def destroy
+    if current_api_v1_user.valid_password?(params[:password])
+      current_api_v1_user.destroy!
+      render json: { message: "アカウントが削除されました" }, status: :ok
+    else
+      render json: { error: "パスワードが正しくありません" }, status: :unprocessable_entity
+    end
+  end
+end

--- a/backend/app/controllers/api/v1/bugs_controller.rb
+++ b/backend/app/controllers/api/v1/bugs_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::BugsController < Api::V1::BaseController
   before_action :authenticate_user!, only: [:create, :update, :destroy]
 
   def index
-    bugs = Bug.where(status: "published").includes(:user).order(created_at: :desc).page(params[:page] || 1).per(10)
+    bugs = Bug.where(status: "published").includes(:user, :likes).order(created_at: :desc).page(params[:page] || 1).per(10)
     render json: bugs, each_serializer: BugListSerializer, status: :ok, meta: pagination(bugs), adapter: :json
   end
 

--- a/backend/app/controllers/api/v1/bugs_controller.rb
+++ b/backend/app/controllers/api/v1/bugs_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::BugsController < Api::V1::BaseController
   before_action :authenticate_user!, only: [:create, :update, :destroy]
 
   def index
-    bugs = Bug.where(status: "published").includes(:user, :likes).order(created_at: :desc).page(params[:page] || 1).per(10)
+    bugs = Bug.where(status: "published").includes(:user).order(created_at: :desc).page(params[:page] || 1).per(10)
     render json: bugs, each_serializer: BugListSerializer, status: :ok, meta: pagination(bugs), adapter: :json
   end
 

--- a/backend/app/models/follow.rb
+++ b/backend/app/models/follow.rb
@@ -1,6 +1,6 @@
 class Follow < ApplicationRecord
-  belongs_to :follower, class_name: "User"
-  belongs_to :followed, class_name: "User"
+  belongs_to :follower, class_name: "User", inverse_of: :active_follows
+  belongs_to :followed, class_name: "User", inverse_of: :passive_follows
 
   validates :follower_id, presence: true
   validates :followed_id, presence: true

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :active_follows, class_name: "Follow", foreign_key: "follower_id", dependent: :destroy, inverse_of: :follower
   has_many :following, through: :active_follows, source: :followed
-  has_many :passive_follows, class_name: "Follow", foreign_key: "followed_id", dependent: :destroy, inverse_of: :following
+  has_many :passive_follows, class_name: "Follow", foreign_key: "followed_id", dependent: :destroy, inverse_of: :followed
   has_many :followers, through: :passive_follows, source: :follower
   has_many :likes, dependent: :destroy
   has_many :liked_bugs, through: :likes, source: :bug

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -2,7 +2,9 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get "hello", to: "hello#index"
-      mount_devise_token_auth_for "User", at: "auth"
+      mount_devise_token_auth_for "User", at: "auth", controllers: {
+        registrations: "api/v1/auth/registrations",
+      }
       namespace :current do
         resource :user, only: [:show]
       end

--- a/frontend/src/components/MypageLayout.tsx
+++ b/frontend/src/components/MypageLayout.tsx
@@ -28,7 +28,7 @@ export const MypageLayout = ({ children }: { children: ReactNode }) => {
               <Link href="">メールアドレス変更</Link>
             </li>
             <li className={isActive('/mypage/account') ? 'text-primary' : ''}>
-              <Link href="">アカウント削除</Link>
+              <Link href="/mypage/account-delete">アカウント削除</Link>
             </li>
           </ul>
         </div>

--- a/frontend/src/components/MypageLayout.tsx
+++ b/frontend/src/components/MypageLayout.tsx
@@ -27,7 +27,7 @@ export const MypageLayout = ({ children }: { children: ReactNode }) => {
             <li className={isActive('/mypage/email') ? 'text-primary' : ''}>
               <Link href="">メールアドレス変更</Link>
             </li>
-            <li className={isActive('/mypage/account') ? 'text-primary' : ''}>
+            <li className={isActive('/mypage/account-delete') ? 'text-primary' : ''}>
               <Link href="/mypage/account-delete">アカウント削除</Link>
             </li>
           </ul>

--- a/frontend/src/components/MypageLayout.tsx
+++ b/frontend/src/components/MypageLayout.tsx
@@ -27,7 +27,11 @@ export const MypageLayout = ({ children }: { children: ReactNode }) => {
             <li className={isActive('/mypage/email') ? 'text-primary' : ''}>
               <Link href="">メールアドレス変更</Link>
             </li>
-            <li className={isActive('/mypage/account-delete') ? 'text-primary' : ''}>
+            <li
+              className={
+                isActive('/mypage/account-delete') ? 'text-primary' : ''
+              }
+            >
               <Link href="/mypage/account-delete">アカウント削除</Link>
             </li>
           </ul>

--- a/frontend/src/features/auth/components/AccountDeleteForm.tsx
+++ b/frontend/src/features/auth/components/AccountDeleteForm.tsx
@@ -1,0 +1,52 @@
+import {
+  UseFormRegister,
+  FieldErrors,
+  UseFormHandleSubmit,
+} from 'react-hook-form'
+import { FormField } from '../ui/FormField'
+import { FormHeading } from '../ui/FormHeading'
+import { SubmitButton } from '../ui/SubmitButton'
+import { DeleteAccountFormValues } from '../validations/deleteAccountValidation'
+
+type AccountDeleteFormProps = {
+  register: UseFormRegister<DeleteAccountFormValues>
+  handleSubmit: UseFormHandleSubmit<DeleteAccountFormValues>
+  errors: FieldErrors<DeleteAccountFormValues>
+  onSubmit: (data: DeleteAccountFormValues) => void
+  isLoading: boolean
+}
+
+export const AccountDeleteForm = ({
+  register,
+  handleSubmit,
+  errors,
+  onSubmit,
+  isLoading,
+}: AccountDeleteFormProps) => {
+  return (
+    <div className="mt-10 flex justify-center">
+      <div className="w-96 rounded-lg bg-white p-6 shadow-lg">
+        <FormHeading
+          title="アカウント削除"
+          description="アカウントを削除するためには、現在のパスワードを入力してください。
+アカウントを削除すると、これまでのデータはすべて失われ、元に戻すことはできません。"
+        />
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          className="space-y-4"
+          role="form"
+        >
+          <FormField
+            label="パスワード"
+            name="password"
+            type="password"
+            register={register}
+            errors={errors}
+            placeholder="8文字以上半角英数字"
+          />
+          <SubmitButton text="送信" isLoading={isLoading} />
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/auth/validations/deleteAccountValidation.ts
+++ b/frontend/src/features/auth/validations/deleteAccountValidation.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+
+export const deleteAccountSchema = z.object({
+  password: z
+    .string()
+    .min(1, { message: 'パスワードは必須です' })
+    .min(8, { message: 'パスワードは8文字以上で入力してください' })
+    .max(128, { message: 'パスワードは128文字以下で入力してください' })
+    .regex(/^[a-zA-Z0-9]+$/, {
+      message: 'パスワードは半角英数字で入力してください',
+    }),
+})
+
+export type DeleteAccountFormValues = z.infer<typeof deleteAccountSchema>

--- a/frontend/src/pages/mypage/account-delete.tsx
+++ b/frontend/src/pages/mypage/account-delete.tsx
@@ -1,0 +1,100 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useMutation } from '@tanstack/react-query'
+import axios, { AxiosError } from 'axios'
+import { useRouter } from 'next/router'
+import { useState } from 'react'
+import { SubmitHandler, useForm } from 'react-hook-form'
+import { toast } from 'react-toastify'
+import { MypageLayout } from '@/components/MypageLayout'
+import { DeleteModal } from '@/components/utilities/DeleteModal'
+import { AccountDeleteForm } from '@/features/auth/components/AccountDeleteForm'
+import {
+  DeleteAccountFormValues,
+  deleteAccountSchema,
+} from '@/features/auth/validations/deleteAccountValidation'
+import { useAuth } from '@/hooks/useAuth'
+import { useRequiredSignedIn } from '@/hooks/useRequiredSignedIn'
+import { API_URLS } from '@/utils/api'
+import { getAuthHeaders } from '@/utils/headers'
+
+const AccountDelete = () => {
+  useRequiredSignedIn()
+  const router = useRouter()
+  const { setCurrentUser, setIsAuthenticated } = useAuth()
+  const [passwordToDelete, setPasswordToDelete] = useState('')
+  const [isModalOpen, setIsModalOpen] = useState(false)
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<DeleteAccountFormValues>({
+    defaultValues: {
+      password: '',
+    },
+    resolver: zodResolver(deleteAccountSchema),
+  })
+
+  const deleteAccount = async (data: DeleteAccountFormValues) => {
+    const response = await axios.delete(API_URLS.AUTH.DELETE_ACCOUNT, {
+      data: data,
+      headers: getAuthHeaders() ?? {},
+    })
+    return response
+  }
+
+  const deleteAccountMutation = useMutation({
+    mutationFn: deleteAccount,
+    onSuccess: (response) => {
+      localStorage.removeItem('access-token')
+      localStorage.removeItem('uid')
+      localStorage.removeItem('client')
+      setCurrentUser(null)
+      setIsAuthenticated(false)
+      toast.success(response.data.message)
+      router.push('/auth/signin')
+    },
+    onError: (error: AxiosError<{ error: string }>) => {
+      console.log(error)
+      const errorMessage =
+        error.response?.data?.error || '予期しないエラーが発生しました'
+      toast.error(errorMessage)
+    },
+  })
+
+  const onSubmit: SubmitHandler<DeleteAccountFormValues> = (
+    data: DeleteAccountFormValues,
+  ) => {
+    console.log('onSubmit called')
+    setPasswordToDelete(data.password)
+    setIsModalOpen(true)
+    console.log(isModalOpen)
+  }
+
+  const handleDeleteConfirm = () => {
+    deleteAccountMutation.mutate({ password: passwordToDelete })
+    setIsModalOpen(false)
+  }
+
+  return (
+    <MypageLayout>
+      <AccountDeleteForm
+        register={register}
+        handleSubmit={handleSubmit}
+        errors={errors}
+        onSubmit={onSubmit}
+        isLoading={deleteAccountMutation.isPending}
+      />
+      {isModalOpen && (
+        <DeleteModal
+          title="本当に削除しますか？"
+          description="※この操作は2度と取り消せません"
+          onClose={() => setIsModalOpen(false)}
+          onClick={handleDeleteConfirm}
+        />
+      )}
+    </MypageLayout>
+  )
+}
+
+export default AccountDelete

--- a/frontend/src/types/CurrentUser.ts
+++ b/frontend/src/types/CurrentUser.ts
@@ -3,4 +3,4 @@ export type CurrentUser = {
   name: string
   image: string
   email: string
-}
+} | null

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -2,6 +2,7 @@ export const API_URLS = {
   AUTH: {
     SIGNUP: `${process.env.NEXT_PUBLIC_API_URL}/auth`,
     SIGNIN: `${process.env.NEXT_PUBLIC_API_URL}/auth/sign_in`,
+    DELETE_ACCOUNT: `${process.env.NEXT_PUBLIC_API_URL}/auth`,
     CONFIRMATION: `${process.env.NEXT_PUBLIC_API_URL}/user/confirmations`,
     CURRENT_USER: `${process.env.NEXT_PUBLIC_API_URL}/current/user`,
   },


### PR DESCRIPTION
## 概要

## 関連するissue番号

- #11 

## 行ったこと

- アカウント削除API作成
- アカウント削除リクエストスペック作成
- アカウント削除ページコンポーネント作成
- アカウント削除バリデーション作成
- アカウント削除フォーム作成
- アカウント削除APIリクエスト作成

## 動作確認

フロントエンド http://localhost:8080/mypage/account-delete
バックエンド http://localhost:3100/api/v1/auth

## その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a secure, user-friendly account deletion process accessible from My Page.
  - Added a dedicated account deletion page where users confirm their decision by entering their current password.
  - Enhanced navigation for account deletion and provided clear success/error feedback during the deletion flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->