### PR TITLE
フォロー・フォロワー一覧機能実装

### DIFF
--- a/backend/app/controllers/api/v1/current/follows_controller.rb
+++ b/backend/app/controllers/api/v1/current/follows_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::FollowsController < Api::V1::BaseController
+class Api::V1::Current::FollowsController < Api::V1::BaseController
   before_action :authenticate_user!
   before_action :prevent_duplicate_follow, only: [:create]
 

--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -4,17 +4,33 @@ class Api::V1::UsersController < Api::V1::BaseController
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
 
   def show
-    user = User.find(params[:id])
+    user = find_user
     render json: user, serializer: UserDetailSerializer, status: :ok
   end
 
   def bugs
-    user = User.find(params[:id])
+    user = find_user
     bugs = user.bugs.where(status: "published").order(created_at: :desc).page(params[:page] || 1).per(10)
     render json: bugs, each_serializer: BugListSerializer, status: :ok, meta: pagination(bugs), adapter: :json
   end
 
+  def followers
+    user = find_user
+    followers = user.followers.order(created_at: :desc)
+    render json: followers, each_serializer: FollowUserSerializer, status: :ok
+  end
+
+  def following
+    user = find_user
+    following = user.following.order(created_at: :desc)
+    render json: following, each_serializer: FollowUserSerializer, status: :ok
+  end
+
   private
+
+    def find_user
+      User.find(params[:id])
+    end
 
     def not_found
       render json: { error: "ユーザーが見つかりません" }, status: :not_found

--- a/backend/app/serializers/follow_user_serializer.rb
+++ b/backend/app/serializers/follow_user_serializer.rb
@@ -1,0 +1,9 @@
+class FollowUserSerializer < BaseUserSerializer
+  attributes :is_following
+
+  # rubocop:disable Naming/PredicateName
+  def is_following
+    current_user&.following?(object) || false
+  end
+  # rubocop:enable Naming/PredicateName
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -6,13 +6,16 @@ Rails.application.routes.draw do
         registrations: "api/v1/auth/registrations",
       }
       namespace :current do
-        resource :user, only: [:show]
+        resource :user, only: [:show] do
+          collection do
+            post :follow, to: "follows#create"
+            delete :unfollow, to: "follows#destroy"
+          end
+        end
       end
       resources :users, only: [:show] do
         member do
           get :bugs, to: "users#bugs"
-          post :follow, to: "follows#create"
-          delete :unfollow, to: "follows#destroy"
         end
       end
       namespace :user do

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
       resources :users, only: [:show] do
         member do
           get :bugs, to: "users#bugs"
+          get :followers, to: "users#followers"
+          get :following, to: "users#following"
         end
       end
       namespace :user do

--- a/backend/spec/requests/api/v1/current/follows_spec.rb
+++ b/backend/spec/requests/api/v1/current/follows_spec.rb
@@ -1,27 +1,27 @@
 require "rails_helper"
 
-RSpec.describe "Api::V1::Follows", type: :request do
+RSpec.describe "Api::V1::Current::Follows", type: :request do
   let(:user) { create(:user) }
   let(:other_user) { create(:user) }
   let(:headers) { user.create_new_auth_token }
 
-  describe "POST /api/v1/users/:id/follow" do
+  describe "POST /api/v1/current/user/follow" do
     context "ログインしている場合" do
       it "他のユーザーをフォローできる" do
-        post follow_api_v1_user_path(other_user), headers: headers
+        post follow_api_v1_current_user_path, params: { id: other_user.id }, headers: headers
         expect(response).to have_http_status(:ok)
         expect(response_json["message"]).to eq("フォローしました")
       end
 
       it "自分をフォローできない" do
-        post follow_api_v1_user_path(user), headers: headers
+        post follow_api_v1_current_user_path, params: { id: user.id }, headers: headers
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response_json["message"]).to eq("自分をフォローすることはできません")
       end
 
       it "既にフォローしている場合はエラーを返す" do
         user.follow(other_user)
-        post follow_api_v1_user_path(other_user), headers: headers
+        post follow_api_v1_current_user_path, params: { id: other_user.id }, headers: headers
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response_json["message"]).to eq("既にフォローしています")
       end
@@ -29,20 +29,20 @@ RSpec.describe "Api::V1::Follows", type: :request do
 
     context "ログインしていない場合" do
       it "401 エラーを返す" do
-        post follow_api_v1_user_path(other_user)
+        post follow_api_v1_current_user_path, params: { id: other_user.id }
         expect(response).to have_http_status(:unauthorized)
       end
     end
   end
 
-  describe "DELETE /api/v1/users/:id/unfollow" do
+  describe "DELETE /api/v1/current/user/unfollow" do
     context "ログインしている場合" do
       before do
         user.follow(other_user)
       end
 
       it "他のユーザーのフォローを解除できる" do
-        delete unfollow_api_v1_user_path(other_user), headers: headers
+        delete unfollow_api_v1_current_user_path, params: { id: other_user.id }, headers: headers
         expect(response).to have_http_status(:ok)
         expect(response_json["message"]).to eq("フォローを解除しました")
       end
@@ -50,7 +50,7 @@ RSpec.describe "Api::V1::Follows", type: :request do
 
     context "ログインしていない場合" do
       it "401 エラーを返す" do
-        delete unfollow_api_v1_user_path(other_user)
+        delete unfollow_api_v1_current_user_path, params: { id: other_user.id }
         expect(response).to have_http_status(:unauthorized)
       end
     end

--- a/backend/spec/requests/api/v1/users_spec.rb
+++ b/backend/spec/requests/api/v1/users_spec.rb
@@ -59,4 +59,61 @@ RSpec.describe "Api::V1::Users", type: :request do
       expect(response_json["meta"]["current_page"]).to eq(1)
     end
   end
+
+  describe "GET /api/v1/users/:id/followers" do
+    let(:user) { create(:user) }
+    let(:other_user) { create(:user) }
+    let(:third_user) { create(:user) }
+
+    before do
+      other_user.follow(user)
+      third_user.follow(user)
+      user.follow(third_user)
+    end
+
+    it "ユーザーのフォロワー一覧を返す" do
+      get followers_api_v1_user_path(user)
+      expect(response).to have_http_status(:ok)
+
+      expect(response_json).to be_an(Array)
+      expect(response_json.size).to eq(2)
+      expect(response_json[0]["id"]).to eq(third_user.id)
+      expect(response_json[1]["id"]).to eq(other_user.id)
+    end
+
+    it "存在しないユーザーのフォロワー一覧を返そうとすると404を返す" do
+      get "/api/v1/users/0/followers"
+      expect(response).to have_http_status(:not_found)
+
+      expect(response_json["error"]).to eq("ユーザーが見つかりません")
+    end
+  end
+
+  describe "GET /api/v1/users/:id/following" do
+    let(:user) { create(:user) }
+    let(:other_user) { create(:user) }
+    let(:third_user) { create(:user) }
+
+    before do
+      other_user.follow(user)
+      third_user.follow(user)
+      user.follow(third_user)
+    end
+
+    it "ユーザーのフォロー一覧を返す" do
+      get following_api_v1_user_path(user)
+      expect(response).to have_http_status(:ok)
+
+      expect(response_json).to be_an(Array)
+      expect(response_json.size).to eq(1)
+      expect(response_json[0]["id"]).to eq(third_user.id)
+    end
+
+    it "存在しないユーザーのフォロー一覧を返そうとすると404を返す" do
+      get "/api/v1/users/0/following"
+      expect(response).to have_http_status(:not_found)
+
+      expect(response_json["error"]).to eq("ユーザーが見つかりません")
+    end
+  end
 end

--- a/frontend/src/components/MypageLayout.tsx
+++ b/frontend/src/components/MypageLayout.tsx
@@ -18,6 +18,9 @@ export const MypageLayout = ({ children }: { children: ReactNode }) => {
             <li className={isActive('/mypage') ? 'text-primary' : ''}>
               <Link href="/mypage">バグ</Link>
             </li>
+            <li className={isActive('/mypage/follows') ? 'text-primary' : ''}>
+              <Link href="/mypage/follows">フォロー・フォロワー</Link>
+            </li>
             <li className={isActive('/mypage/profile') ? 'text-primary' : ''}>
               <Link href="">プロフィール</Link>
             </li>

--- a/frontend/src/features/mypage/types/Tab.ts
+++ b/frontend/src/features/mypage/types/Tab.ts
@@ -1,6 +1,4 @@
-import { TabValue } from './TabValue'
-
-export type Tab = {
+export type Tab<T extends string> = {
   label: string
-  value: TabValue
+  value: T
 }

--- a/frontend/src/features/mypage/types/TabValue.ts
+++ b/frontend/src/features/mypage/types/TabValue.ts
@@ -5,3 +5,5 @@ export type TabValue =
   | 'draft'
   | 'published'
   | 'liked'
+
+export type FollowTabValue = 'followers' | 'following'

--- a/frontend/src/features/mypage/ui/Tabs.tsx
+++ b/frontend/src/features/mypage/ui/Tabs.tsx
@@ -1,21 +1,26 @@
 import { Tab } from '../types/Tab'
-import { TabValue } from '../types/TabValue'
 
-type TabsProps = {
-  tabs: Tab[]
-  selectedTab: TabValue
-  onClick: (tabValue: TabValue) => void
+type TabsProps<T extends string> = {
+  tabs: Tab<T>[]
+  selectedTab: T
+  onClick: (tabValue: T) => void
 }
 
-export const Tabs = ({ tabs, selectedTab, onClick }: TabsProps) => {
+export const Tabs = <T extends string>({
+  tabs,
+  selectedTab,
+  onClick,
+}: TabsProps<T>) => {
   return (
     <div>
       <div role="tablist" className="tabs">
         {tabs.map((tab) => (
           <a
-            key={tab.value}
+            key={String(tab.value)}
             role="tab"
-            className={`tab font-bold ${selectedTab === tab.value ? 'tab-active text-primary' : ''}`}
+            className={`tab font-bold ${
+              selectedTab === tab.value ? 'tab-active text-primary' : ''
+            }`}
             onClick={() => onClick(tab.value)}
           >
             {tab.label}

--- a/frontend/src/features/user/components/FollowButton.tsx
+++ b/frontend/src/features/user/components/FollowButton.tsx
@@ -13,7 +13,11 @@ export const FollowButton = ({
 }: FollowButtonProps) => {
   return (
     <button
-      className={`btn ${isFollowing ? 'btn-error' : 'btn-primary'}`}
+      className={`group btn w-24 p-0.5 text-xs transition-colors duration-300 md:w-32 md:p-2 md:text-base ${
+        isFollowing
+          ? 'bg-black text-white hover:bg-red-600'
+          : 'border border-black bg-white text-black hover:bg-gray-100'
+      }`}
       disabled={isLoading}
       onClick={isFollowing ? onUnfollow : onFollow}
     >
@@ -23,7 +27,10 @@ export const FollowButton = ({
           role="status"
         ></span>
       ) : isFollowing ? (
-        'フォロー解除'
+        <>
+          <span className="group-hover:hidden">フォロー中</span>
+          <span className="hidden group-hover:inline">フォロー解除</span>
+        </>
       ) : (
         'フォロー'
       )}

--- a/frontend/src/features/user/components/FollowList.tsx
+++ b/frontend/src/features/user/components/FollowList.tsx
@@ -1,0 +1,33 @@
+import { FollowListItem } from './FollowListItem'
+import { User } from '@/types/User'
+
+type FollowListProps = {
+  users: User[]
+  isLoading: boolean
+  currentUserId?: number
+  onFollow: (userId: number) => void
+  onUnfollow: (userId: number) => void
+}
+
+export const FollowList = ({
+  users,
+  isLoading,
+  currentUserId,
+  onFollow,
+  onUnfollow,
+}: FollowListProps) => {
+  return (
+    <ul>
+      {users?.map((user) => (
+        <FollowListItem
+          key={user.id}
+          user={user}
+          isLoading={isLoading}
+          onFollow={onFollow}
+          onUnfollow={onUnfollow}
+          currentUserId={currentUserId}
+        />
+      ))}
+    </ul>
+  )
+}

--- a/frontend/src/features/user/components/FollowListItem.tsx
+++ b/frontend/src/features/user/components/FollowListItem.tsx
@@ -1,0 +1,45 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import { FollowButton } from './FollowButton'
+import { User } from '@/types/User'
+
+type FollowListItemProps = {
+  user: User
+  isLoading: boolean
+  currentUserId?: number
+  onFollow: (userId: number) => void
+  onUnfollow: (userId: number) => void
+}
+
+export const FollowListItem = ({
+  user,
+  isLoading,
+  currentUserId,
+  onFollow,
+  onUnfollow,
+}: FollowListItemProps) => {
+  return (
+    <li className="mb-4 flex h-[64px] items-center justify-between rounded-md bg-base-100 p-4 shadow-xl">
+      <div className="flex grow items-center">
+        <Image
+          src={user.image || '/images/default-avatar.png'}
+          alt={user.name}
+          width={40}
+          height={40}
+          className="mr-4 rounded-full"
+        />
+        <Link href={`/users/${user.id}`} className="text-sm font-medium">
+          {user.name || 'aaaaaaaaaaaaaaa'}
+        </Link>
+      </div>
+      {user.id !== currentUserId && (
+        <FollowButton
+          isFollowing={user.isFollowing}
+          isLoading={isLoading}
+          onFollow={() => onFollow(user.id)}
+          onUnfollow={() => onUnfollow(user.id)}
+        />
+      )}
+    </li>
+  )
+}

--- a/frontend/src/pages/mypage/account-delete.tsx
+++ b/frontend/src/pages/mypage/account-delete.tsx
@@ -65,10 +65,8 @@ const AccountDelete = () => {
   const onSubmit: SubmitHandler<DeleteAccountFormValues> = (
     data: DeleteAccountFormValues,
   ) => {
-    console.log('onSubmit called')
     setPasswordToDelete(data.password)
     setIsModalOpen(true)
-    console.log(isModalOpen)
   }
 
   const handleDeleteConfirm = () => {

--- a/frontend/src/pages/mypage/follows.tsx
+++ b/frontend/src/pages/mypage/follows.tsx
@@ -1,0 +1,160 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import axios from 'axios'
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import { toast } from 'react-toastify'
+import { MypageLayout } from '@/components/MypageLayout'
+import { Loading } from '@/components/utilities/Loading'
+import { NoData } from '@/components/utilities/NoData'
+import { Tab } from '@/features/mypage/types/Tab'
+import { FollowTabValue } from '@/features/mypage/types/TabValue'
+import { Tabs } from '@/features/mypage/ui/Tabs'
+import { FollowList } from '@/features/user/components/FollowList'
+import { useAuth } from '@/hooks/useAuth'
+import { useRequiredSignedIn } from '@/hooks/useRequiredSignedIn'
+import { User } from '@/types/User'
+import { fetcher } from '@/utils'
+import { API_URLS } from '@/utils/api'
+import { getAuthHeaders } from '@/utils/headers'
+
+const tabs: Tab<FollowTabValue>[] = [
+  {
+    label: 'フォロー',
+    value: 'following',
+  },
+  {
+    label: 'フォロワー',
+    value: 'followers',
+  },
+]
+
+const FollowIndex = () => {
+  useRequiredSignedIn()
+  const router = useRouter()
+  const { tab } = router.query
+  const [selectedTab, setSelectedTab] = useState<FollowTabValue>('following')
+  const { currentUser } = useAuth()
+  const queryClient = useQueryClient()
+  const currentUserId = currentUser?.id
+
+  useEffect(() => {
+    if (tab) {
+      setSelectedTab(tab as FollowTabValue)
+    }
+  }, [tab])
+
+  const { data, isPending, isFetching } = useQuery<User[]>({
+    queryKey: ['follows', selectedTab],
+    queryFn: () => {
+      if (selectedTab === 'following') {
+        return fetcher(API_URLS.USER.FOLLOWING(String(currentUserId)))
+      }
+      if (selectedTab === 'followers') {
+        return fetcher(API_URLS.USER.FOLLOWERS(String(currentUserId)))
+      }
+      return Promise.reject('Invalid tab')
+    },
+    enabled: !!currentUserId,
+  })
+
+  const follow = useMutation({
+    mutationFn: async (userId: number) => {
+      const res = await axios.post(
+        API_URLS.CURRENT.FOLLOW,
+        { id: userId },
+        { headers: getAuthHeaders() ?? {} },
+      )
+      return res.data
+    },
+    onSuccess: (data) => {
+      toast.success(data.message)
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['follows', selectedTab],
+      })
+    },
+  })
+
+  const unfollow = useMutation({
+    mutationFn: async (userId: number) => {
+      const res = await axios.delete(API_URLS.CURRENT.UNFOLLOW, {
+        data: { id: userId },
+        headers: getAuthHeaders() ?? {},
+      })
+      return res.data
+    },
+    onSuccess: (data) => {
+      toast.success(data.message)
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['follows', selectedTab],
+      })
+    },
+  })
+
+  const handleFollow = (userId: number) => {
+    follow.mutate(userId)
+  }
+
+  const handleUnfollow = (userId: number) => {
+    unfollow.mutate(userId)
+  }
+
+  const handleTabChange = (tabValue: FollowTabValue) => {
+    router.push({
+      pathname: router.pathname,
+      query: { ...router.query, tab: tabValue },
+    })
+  }
+
+  return (
+    <MypageLayout>
+      <div className="mx-auto my-12 w-full max-w-full p-4 md:max-w-4xl lg:max-w-3xl">
+        <div className="mt-8 flex justify-center">
+          <Tabs<FollowTabValue>
+            tabs={tabs}
+            selectedTab={selectedTab}
+            onClick={handleTabChange}
+          />
+        </div>
+
+        <div className="p-4">
+          {isFetching && <Loading />}
+          {selectedTab === 'following' ? (
+            <div className="mt-4">
+              {data?.length === 0 ? (
+                <NoData message="フォローしているユーザーはいません" />
+              ) : (
+                <FollowList
+                  users={data ?? []}
+                  isLoading={isPending}
+                  currentUserId={currentUser?.id}
+                  onFollow={handleFollow}
+                  onUnfollow={handleUnfollow}
+                />
+              )}
+            </div>
+          ) : (
+            <div className="mt-4">
+              {data?.length === 0 ? (
+                <NoData message="フォロワーはいません" />
+              ) : (
+                <FollowList
+                  users={data ?? []}
+                  isLoading={isPending}
+                  currentUserId={currentUser?.id}
+                  onFollow={handleFollow}
+                  onUnfollow={handleUnfollow}
+                />
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </MypageLayout>
+  )
+}
+
+export default FollowIndex

--- a/frontend/src/pages/mypage/index.tsx
+++ b/frontend/src/pages/mypage/index.tsx
@@ -15,7 +15,7 @@ import { Meta } from '@/types/Meta'
 import { fetcher } from '@/utils'
 import { API_URLS } from '@/utils/api'
 
-const tabs: Tab[] = [
+const tabs: Tab<TabValue>[] = [
   {
     label: `全て`,
     value: 'all',
@@ -70,7 +70,11 @@ const Mypage = () => {
   return (
     <MypageLayout>
       <div className="mt-8 flex justify-center">
-        <Tabs tabs={tabs} selectedTab={selectedTab} onClick={setSelectedTab} />
+        <Tabs<TabValue>
+          tabs={tabs}
+          selectedTab={selectedTab}
+          onClick={setSelectedTab}
+        />
       </div>
 
       <div className="mt-4 text-right font-bold text-gray-600">

--- a/frontend/src/pages/users/[id].tsx
+++ b/frontend/src/pages/users/[id].tsx
@@ -51,10 +51,10 @@ const UserDetail = () => {
   const queryClient = useQueryClient()
 
   const follow = useMutation({
-    mutationFn: async () => {
+    mutationFn: async (userId: number) => {
       const res = await axios.post(
-        API_URLS.USER.FOLLOW(String(id)),
-        {},
+        API_URLS.CURRENT.FOLLOW,
+        { id: userId },
         { headers: getAuthHeaders() ?? {} },
       )
       return res.data
@@ -70,8 +70,9 @@ const UserDetail = () => {
   })
 
   const unfollow = useMutation({
-    mutationFn: async () => {
-      const res = await axios.delete(API_URLS.USER.UNFOLLOW(String(id)), {
+    mutationFn: async (userId: number) => {
+      const res = await axios.delete(API_URLS.CURRENT.UNFOLLOW, {
+        data: { id: userId },
         headers: getAuthHeaders() ?? {},
       })
       return res.data
@@ -86,6 +87,14 @@ const UserDetail = () => {
       })
     },
   })
+
+  const handleFollow = (userId: number) => {
+    follow.mutate(userId)
+  }
+
+  const handleUnfollow = (userId: number) => {
+    unfollow.mutate(userId)
+  }
 
   return (
     <Layout>
@@ -110,8 +119,8 @@ const UserDetail = () => {
                     <FollowButton
                       isFollowing={user.isFollowing}
                       isLoading={follow.isPending || unfollow.isPending}
-                      onFollow={() => follow.mutate()}
-                      onUnfollow={() => unfollow.mutate()}
+                      onFollow={() => handleFollow(user.id)}
+                      onUnfollow={() => handleUnfollow(user.id)}
                     />
                   )}
                 </div>
@@ -119,13 +128,13 @@ const UserDetail = () => {
             </div>
 
             <div className="mt-4 flex justify-center gap-4 text-lg">
-              <Link href={`/users/${id}/follows`}>
+              <Link href={`/users/${id}/follows?tab=following`}>
                 <div className="cursor-pointer underline">
                   フォロー{' '}
                   <span className="font-bold">{user?.followingCount}</span>
                 </div>
               </Link>
-              <Link href={`/users/${id}/follows`}>
+              <Link href={`/users/${id}/follows?tab=followers`}>
                 <div className="cursor-pointer underline">
                   フォロワー{' '}
                   <span className="font-bold">{user?.followersCount}</span>

--- a/frontend/src/pages/users/[id]/follows.tsx
+++ b/frontend/src/pages/users/[id]/follows.tsx
@@ -1,0 +1,157 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import axios from 'axios'
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import { toast } from 'react-toastify'
+import { Layout } from '@/components/Layout'
+import { NoData } from '@/components/utilities/NoData'
+import { Tab } from '@/features/mypage/types/Tab'
+import { FollowTabValue } from '@/features/mypage/types/TabValue'
+import { Tabs } from '@/features/mypage/ui/Tabs'
+import { FollowList } from '@/features/user/components/FollowList'
+import { useAuth } from '@/hooks/useAuth'
+import { useRequiredSignedIn } from '@/hooks/useRequiredSignedIn'
+import { User } from '@/types/User'
+import { fetcher } from '@/utils'
+import { API_URLS } from '@/utils/api'
+import { getAuthHeaders } from '@/utils/headers'
+
+const tabs: Tab<FollowTabValue>[] = [
+  {
+    label: 'フォロー',
+    value: 'following',
+  },
+  {
+    label: 'フォロワー',
+    value: 'followers',
+  },
+]
+
+const FollowIndex = () => {
+  useRequiredSignedIn()
+  const router = useRouter()
+  const { id, tab } = router.query
+  const [selectedTab, setSelectedTab] = useState<FollowTabValue>('following')
+  const { currentUser } = useAuth()
+  const queryClient = useQueryClient()
+
+  useEffect(() => {
+    if (tab) {
+      setSelectedTab(tab as FollowTabValue)
+    }
+  }, [tab])
+
+  const { data, isPending } = useQuery<User[]>({
+    queryKey: ['follows', selectedTab],
+    queryFn: () => {
+      if (selectedTab === 'following') {
+        return fetcher(API_URLS.USER.FOLLOWING(String(id)))
+      }
+      if (selectedTab === 'followers') {
+        return fetcher(API_URLS.USER.FOLLOWERS(String(id)))
+      }
+      return Promise.reject('Invalid tab')
+    },
+    enabled: !!id,
+  })
+
+  const follow = useMutation({
+    mutationFn: async (userId: number) => {
+      const res = await axios.post(
+        API_URLS.CURRENT.FOLLOW,
+        { id: userId },
+        { headers: getAuthHeaders() ?? {} },
+      )
+      return res.data
+    },
+    onSuccess: (data) => {
+      toast.success(data.message)
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['follows', selectedTab],
+      })
+    },
+  })
+
+  const unfollow = useMutation({
+    mutationFn: async (userId: number) => {
+      const res = await axios.delete(API_URLS.CURRENT.UNFOLLOW, {
+        data: { id: userId },
+        headers: getAuthHeaders() ?? {},
+      })
+      return res.data
+    },
+    onSuccess: (data) => {
+      toast.success(data.message)
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['follows', selectedTab],
+      })
+    },
+  })
+
+  const handleFollow = (userId: number) => {
+    follow.mutate(userId)
+  }
+
+  const handleUnfollow = (userId: number) => {
+    unfollow.mutate(userId)
+  }
+
+  const handleTabChange = (tabValue: FollowTabValue) => {
+    router.push({
+      pathname: router.pathname,
+      query: { ...router.query, tab: tabValue },
+    })
+  }
+
+  return (
+    <Layout>
+      <div className="mx-auto my-12 w-full max-w-full p-4 md:max-w-4xl lg:max-w-3xl">
+        <div className="mt-8 flex justify-center">
+          <Tabs<FollowTabValue>
+            tabs={tabs}
+            selectedTab={selectedTab}
+            onClick={handleTabChange}
+          />
+        </div>
+
+        <div className="p-4">
+          {selectedTab === 'following' ? (
+            <div className="mt-4">
+              {data?.length === 0 ? (
+                <NoData message="フォローしているユーザーはいません" />
+              ) : (
+                <FollowList
+                  users={data ?? []}
+                  isLoading={isPending}
+                  currentUserId={currentUser?.id}
+                  onFollow={handleFollow}
+                  onUnfollow={handleUnfollow}
+                />
+              )}
+            </div>
+          ) : (
+            <div className="mt-4">
+              {data?.length === 0 ? (
+                <NoData message="フォロワーはいません" />
+              ) : (
+                <FollowList
+                  users={data ?? []}
+                  isLoading={isPending}
+                  currentUserId={currentUser?.id}
+                  onFollow={handleFollow}
+                  onUnfollow={handleUnfollow}
+                />
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </Layout>
+  )
+}
+
+export default FollowIndex

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -6,14 +6,14 @@ export const API_URLS = {
     CONFIRMATION: `${process.env.NEXT_PUBLIC_API_URL}/user/confirmations`,
     CURRENT_USER: `${process.env.NEXT_PUBLIC_API_URL}/current/user`,
   },
+  CURRENT: {
+    FOLLOW: `${process.env.NEXT_PUBLIC_API_URL}/current/user/follow`,
+    UNFOLLOW: `${process.env.NEXT_PUBLIC_API_URL}/current/user/unfollow`,
+  },
   USER: {
     SHOW: (id: string) => `${process.env.NEXT_PUBLIC_API_URL}/users/${id}`,
     BUG: (id: string, page: number) =>
       `${process.env.NEXT_PUBLIC_API_URL}/users/${id}/bugs?page=${page}`,
-    FOLLOW: (id: string) =>
-      `${process.env.NEXT_PUBLIC_API_URL}/users/${id}/follow`,
-    UNFOLLOW: (id: string) =>
-      `${process.env.NEXT_PUBLIC_API_URL}/users/${id}/unfollow`,
   },
   BUG: {
     INDEX: (page: number) =>

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -14,6 +14,10 @@ export const API_URLS = {
     SHOW: (id: string) => `${process.env.NEXT_PUBLIC_API_URL}/users/${id}`,
     BUG: (id: string, page: number) =>
       `${process.env.NEXT_PUBLIC_API_URL}/users/${id}/bugs?page=${page}`,
+    FOLLOWERS: (id: string) =>
+      `${process.env.NEXT_PUBLIC_API_URL}/users/${id}/followers`,
+    FOLLOWING: (id: string) =>
+      `${process.env.NEXT_PUBLIC_API_URL}/users/${id}/following`,
   },
   BUG: {
     INDEX: (page: number) =>


### PR DESCRIPTION
## 概要

## 関連するissue番号

- #25 
- #79 

## 行ったこと

- フォロー・フォロー解除機能をユーザー詳細とフォロー・フォロワー一覧で共通で使えるように修正
- フォロー・フォロワー一覧取得API作成
- フォロー・フォロワー一覧取得のリクエストスペック作成
- フォロー・フォロワー一覧ページコンポーネントとAPIリクエスト作成
- マイページでのフォロー・フォロワー一覧ページコンポーネントとAPIリクエスト作成

## 動作確認

フロントエンド http://localhost:8080/mypage/follows http://localhost:8080/users/1/follows
バックエンド http://localhost:3100/api/v1/users/1/followers http://localhost:3100/api/v1/users/1/following

## その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Launched enhanced follow/unfollow functionality with dedicated pages to view followers and following lists.
  - Introduced a new navigation link in the MyPage section to easily access follow-related features.
  - Improved the follow experience on user profiles with more dynamic interactions.

- **Style**
  - Upgraded button styling to provide interactive visual feedback on hover, making follow actions clearer and more engaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->