### PR TITLE
パスワード変更機能実装

### DIFF
--- a/backend/app/controllers/api/v1/auth/passwords_controller.rb
+++ b/backend/app/controllers/api/v1/auth/passwords_controller.rb
@@ -1,0 +1,27 @@
+class Api::V1::Auth::PasswordsController < DeviseTokenAuth::PasswordsController
+  before_action :authenticate_api_v1_user!, only: [:update]
+
+  def update
+    user = current_api_v1_user
+
+    unless user.valid_password?(password_update_params[:current_password])
+      return render json: { errors: ["現在のパスワードが間違っています"] }, status: :unprocessable_entity
+    end
+
+    if password_update_params[:current_password] == password_update_params[:password]
+      return render json: { errors: ["新しいパスワードは現在のパスワードと異なっている必要があります"] }, status: :unprocessable_entity
+    end
+
+    if user.update(password_update_params.except(:current_password))
+      render json: { message: "パスワードが変更されました" }, status: :ok
+    else
+      render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+    def password_update_params
+      params.permit(:current_password, :password, :password_confirmation)
+    end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
       get "hello", to: "hello#index"
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
+        passwords: "api/v1/auth/passwords",
       }
       namespace :current do
         resource :user, only: [:show] do

--- a/backend/spec/requests/api/v1/auth/passwords_spec.rb
+++ b/backend/spec/requests/api/v1/auth/passwords_spec.rb
@@ -1,0 +1,92 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Auth::Passwords", type: :request do
+  describe "PATCH /api/v1/auth" do
+    let(:user) { create(:user, password: "password123") }
+    let(:headers) { user.create_new_auth_token }
+
+    let(:valid_params) do
+      {
+        current_password: "password123",
+        password: "newpassword123",
+        password_confirmation: "newpassword123",
+      }
+    end
+
+    let(:invalid_params_wrong_current_password) do
+      {
+        current_password: "wrongpassword",
+        password: "newpassword123",
+        password_confirmation: "newpassword123",
+      }
+    end
+
+    let(:invalid_params_same_password) do
+      {
+        current_password: "password123",
+        password: "password123",
+        password_confirmation: "password123",
+      }
+    end
+
+    let(:invalid_params_mismatch_confirmation) do
+      {
+        current_password: "password123",
+        password: "newpassword123",
+        password_confirmation: "wrongpassword123",
+      }
+    end
+
+    context "ログインしている場合" do
+      context "入力するパラメータが正しい場合" do
+        it "パスワードの変更が成功する" do
+          patch api_v1_user_password_path, params: valid_params, headers: headers
+
+          expect(response).to have_http_status(:ok)
+          expect(response_json["message"]).to eq("パスワードが変更されました")
+
+          user.reload
+          expect(user).not_to be_valid_password("password123")
+          expect(user).to be_valid_password("newpassword123")
+        end
+      end
+
+      context "入力するパラメータが間違っている場合" do
+        it "現在のパスワードが異なる場合、パスワードの変更が失敗する" do
+          patch api_v1_user_password_path, params: invalid_params_wrong_current_password, headers: headers
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response_json["errors"]).to include("現在のパスワードが間違っています")
+
+          user.reload
+          expect(user).to be_valid_password("password123")
+        end
+
+        it "新しいパスワードが現在のパスワードと同じ場合、パスワードの変更が失敗する" do
+          patch api_v1_user_password_path, params: invalid_params_same_password, headers: headers
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response_json["errors"]).to include("新しいパスワードは現在のパスワードと異なっている必要があります")
+
+          user.reload
+          expect(user).to be_valid_password("password123")
+        end
+
+        it "新しいパスワードが確認用のパスワードと異なる場合、パスワードの変更が失敗する" do
+          patch api_v1_user_password_path, params: invalid_params_mismatch_confirmation, headers: headers
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response_json["errors"]).to include("パスワード確認用とパスワードの入力が一致しません")
+
+          user.reload
+          expect(user).to be_valid_password("password123")
+        end
+      end
+    end
+
+    context "ログインしていない場合" do
+      it "401 エラーが返る" do
+        patch api_v1_user_password_path, params: valid_params
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/frontend/src/components/MypageLayout.tsx
+++ b/frontend/src/components/MypageLayout.tsx
@@ -24,8 +24,12 @@ export const MypageLayout = ({ children }: { children: ReactNode }) => {
             <li className={isActive('/mypage/profile') ? 'text-primary' : ''}>
               <Link href="">プロフィール</Link>
             </li>
-            <li className={isActive('/mypage/pass') ? 'text-primary' : ''}>
-              <Link href="">パスワード変更</Link>
+            <li
+              className={
+                isActive('/mypage/password-change') ? 'text-primary' : ''
+              }
+            >
+              <Link href="/mypage/password-change">パスワード変更</Link>
             </li>
             <li className={isActive('/mypage/email') ? 'text-primary' : ''}>
               <Link href="">メールアドレス変更</Link>

--- a/frontend/src/features/mypage/components/PasswordChangeForm.tsx
+++ b/frontend/src/features/mypage/components/PasswordChangeForm.tsx
@@ -1,0 +1,64 @@
+import {
+  UseFormRegister,
+  FieldErrors,
+  UseFormHandleSubmit,
+} from 'react-hook-form'
+import { ChangePasswordFormValues } from '../validations/changePasswordValidation'
+import { FormField } from '@/features/auth/ui/FormField'
+import { FormHeading } from '@/features/auth/ui/FormHeading'
+import { SubmitButton } from '@/features/auth/ui/SubmitButton'
+
+type AccountDeleteFormProps = {
+  register: UseFormRegister<ChangePasswordFormValues>
+  handleSubmit: UseFormHandleSubmit<ChangePasswordFormValues>
+  errors: FieldErrors<ChangePasswordFormValues>
+  onSubmit: (data: ChangePasswordFormValues) => void
+  isLoading: boolean
+}
+
+export const PasswordChangeForm = ({
+  register,
+  handleSubmit,
+  errors,
+  onSubmit,
+  isLoading,
+}: AccountDeleteFormProps) => {
+  return (
+    <div className="mt-10 flex justify-center">
+      <div className="w-96 rounded-lg bg-white p-6 shadow-lg">
+        <FormHeading title="パスワード変更" />
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          className="space-y-4"
+          role="form"
+        >
+          <FormField
+            label="現在のパスワード"
+            name="current_password"
+            type="password"
+            register={register}
+            errors={errors}
+            placeholder="8文字以上半角英数字"
+          />
+          <FormField
+            label="新しいパスワード"
+            name="password"
+            type="password"
+            register={register}
+            errors={errors}
+            placeholder="8文字以上半角英数字"
+          />
+          <FormField
+            label="新しいパスワード確認"
+            name="password_confirmation"
+            type="password"
+            register={register}
+            errors={errors}
+            placeholder="8文字以上半角英数字"
+          />
+          <SubmitButton text="変更" isLoading={isLoading} />
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/mypage/validations/changePasswordValidation.ts
+++ b/frontend/src/features/mypage/validations/changePasswordValidation.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod'
+
+export const changePasswordSchema = z
+  .object({
+    current_password: z
+      .string()
+      .min(8, { message: '現在のパスワードは8文字以上で入力してください' })
+      .max(128, { message: '現在のパスワードは128文字以下で入力してください' })
+      .regex(/^[a-zA-Z0-9]+$/, {
+        message: '現在のパスワードは半角英数字で入力してください',
+      }),
+    password: z
+      .string()
+      .min(8, { message: '新しいパスワードは8文字以上で入力してください' })
+      .max(128, { message: '新しいパスワードは128文字以下で入力してください' })
+      .regex(/^[a-zA-Z0-9]+$/, {
+        message: '新しいパスワードは半角英数字で入力してください',
+      }),
+    password_confirmation: z
+      .string()
+      .min(8, { message: '確認用のパスワードは8文字以上で入力してください' })
+      .max(128, {
+        message: '確認用のパスワードは128文字以下で入力してください',
+      })
+      .regex(/^[a-zA-Z0-9]+$/, {
+        message: '確認用のパスワードは半角英数字で入力してください',
+      }),
+  })
+  .refine((data) => data.password !== data.current_password, {
+    message: '現在のパスワードと新しいパスワードが同じです',
+    path: ['password'],
+  })
+  .refine((data) => data.password === data.password_confirmation, {
+    message: '新しいパスワードが一致しません',
+    path: ['password_confirmation'],
+  })
+
+export type ChangePasswordFormValues = z.infer<typeof changePasswordSchema>

--- a/frontend/src/pages/auth/signin.tsx
+++ b/frontend/src/pages/auth/signin.tsx
@@ -40,7 +40,7 @@ const Signin = () => {
       setCurrentUser(response.data)
       setIsAuthenticated(true)
       toast.success('ログインしました')
-      router.push('/')
+      router.push('/mypage')
     },
     onError: (error: AxiosError<{ errors: string[] }>) => {
       console.log(error)

--- a/frontend/src/pages/mypage/password-change.tsx
+++ b/frontend/src/pages/mypage/password-change.tsx
@@ -1,0 +1,69 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useMutation } from '@tanstack/react-query'
+import axios, { AxiosError } from 'axios'
+import { useRouter } from 'next/router'
+import { SubmitHandler, useForm } from 'react-hook-form'
+import { toast } from 'react-toastify'
+import { MypageLayout } from '@/components/MypageLayout'
+import { PasswordChangeForm } from '@/features/mypage/components/PasswordChangeForm'
+import {
+  ChangePasswordFormValues,
+  changePasswordSchema,
+} from '@/features/mypage/validations/changePasswordValidation'
+import { useRequiredSignedIn } from '@/hooks/useRequiredSignedIn'
+import { API_URLS } from '@/utils/api'
+import { getAuthHeaders } from '@/utils/headers'
+
+const PasswordChange = () => {
+  useRequiredSignedIn()
+  const router = useRouter()
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ChangePasswordFormValues>({
+    resolver: zodResolver(changePasswordSchema),
+  })
+
+  const changePassword = async (data: ChangePasswordFormValues) => {
+    const response = await axios.patch(API_URLS.AUTH.PASSWORD, data, {
+      headers: getAuthHeaders() ?? {},
+    })
+    return response
+  }
+
+  const changePasswordMutation = useMutation({
+    mutationFn: changePassword,
+    onSuccess: (response) => {
+      toast.success(response.data.message)
+      router.push('/mypage')
+    },
+    onError: (error: AxiosError<{ errors: string[] }>) => {
+      console.log(error)
+      const errorMessage =
+        error.response?.data?.errors[0] || '予期しないエラーが発生しました'
+      toast.error(errorMessage)
+    },
+  })
+
+  const onSubmit: SubmitHandler<ChangePasswordFormValues> = (
+    data: ChangePasswordFormValues,
+  ) => {
+    changePasswordMutation.mutate(data)
+  }
+
+  return (
+    <MypageLayout>
+      <PasswordChangeForm
+        register={register}
+        handleSubmit={handleSubmit}
+        errors={errors}
+        onSubmit={onSubmit}
+        isLoading={changePasswordMutation.isPending}
+      />
+    </MypageLayout>
+  )
+}
+
+export default PasswordChange

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -5,6 +5,7 @@ export const API_URLS = {
     DELETE_ACCOUNT: `${process.env.NEXT_PUBLIC_API_URL}/auth`,
     CONFIRMATION: `${process.env.NEXT_PUBLIC_API_URL}/user/confirmations`,
     CURRENT_USER: `${process.env.NEXT_PUBLIC_API_URL}/current/user`,
+    PASSWORD: `${process.env.NEXT_PUBLIC_API_URL}/auth/password`,
   },
   CURRENT: {
     FOLLOW: `${process.env.NEXT_PUBLIC_API_URL}/current/user/follow`,


### PR DESCRIPTION
## 概要

パスワード変更機能実装

## 関連するissue番号

- #9 

## 行ったこと

- パスワード変更のAPI作成
- パスワード変更のリクエストスペック作成
- パスワード変更のページコンポーネント、フォーム、バリデーション、APIリクエスト作成

## 動作確認

フロントエンド http://localhost:8080/mypage/password-change
バックエンド http://localhost:3100/api/v1/auth/password

## その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a password update flow that lets users securely change their passwords with enhanced validation and clear messaging.
  - Updated the personal dashboard to include a new password change option with an improved navigation link.
  - Modified the sign-in process so that users are redirected to their dashboard upon successful login.
  - Enhanced API configurations to support these password management features seamlessly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->