### PR TITLE
プロフィール編集機能実装

### DIFF
--- a/backend/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/backend/app/controllers/api/v1/auth/sessions_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::Auth::SessionsController < DeviseTokenAuth::SessionsController
+  def render_create_success
+    render json: @resource, serializer: UserSerializer
+  end
+end

--- a/backend/app/controllers/api/v1/current/users_controller.rb
+++ b/backend/app/controllers/api/v1/current/users_controller.rb
@@ -2,6 +2,6 @@ class Api::V1::Current::UsersController < Api::V1::BaseController
   before_action :authenticate_user!
 
   def show
-    render json: current_user, serializer: CurrentUserSerializer
+    render json: current_user, serializer: UserSerializer
   end
 end

--- a/backend/app/controllers/api/v1/mypage/profiles_controller.rb
+++ b/backend/app/controllers/api/v1/mypage/profiles_controller.rb
@@ -1,0 +1,22 @@
+class Api::V1::Mypage::ProfilesController < Api::V1::BaseController
+  before_action :authenticate_user!
+
+  def show
+    render json: current_user, serializer: ProfileSerializer
+  end
+
+  def update
+    current_user.profile_update = true
+    if current_user.update(profile_params)
+      render json: { message: "プロフィールを更新しました" }
+    else
+      render json: { errors: current_user.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+    def profile_params
+      params.permit(:image, :name, :nickname, :bio, :github_url, :website_url)
+    end
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -20,11 +20,32 @@ class User < ApplicationRecord
   has_one_attached :image
 
   PASSWORD_COMPLEXITY_REGEX = /\A(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,128}\z/
+  MAX_IMAGE_SIZE = 3.megabytes
+  ALLOWED_CONTENT_TYPES = %w[image/jpeg image/jpg image/png image/webp].freeze
+
+  attr_accessor :profile_update
 
   validates :email, length: { maximum: 255 }, format: { with: URI::MailTo::EMAIL_REGEXP, message: I18n.t("errors.messages.invalid_email") }
   validates :password,
             format: { with: PASSWORD_COMPLEXITY_REGEX, message: I18n.t("errors.messages.password_complexity") }, if: :new_record?
   validates :password_confirmation, presence: true, if: :new_record?
+  validate :validate_image, if: -> { image.attached? && profile_update? }
+  validates :name, presence: true, length: {
+    maximum: 255,
+  }, if: :profile_update?
+  validates :bio, length: {
+    maximum: 500,
+  }, if: :profile_update?
+  validates :github_url,
+            length: { maximum: 255 },
+            format: { with: URI::DEFAULT_PARSER.make_regexp, message: "は有効なURLではありません" },
+            allow_blank: true,
+            if: :profile_update?
+  validates :website_url,
+            length: { maximum: 255 },
+            format: { with: URI::DEFAULT_PARSER.make_regexp, message: "は有効なURLではありません" },
+            allow_blank: true,
+            if: :profile_update?
 
   def follow(user)
     active_follows.create(followed_id: user.id)
@@ -36,6 +57,10 @@ class User < ApplicationRecord
 
   def following?(user)
     following.include?(user)
+  end
+
+  def profile_update?
+    profile_update == true
   end
 
   def as_json(options = {})
@@ -58,5 +83,20 @@ class User < ApplicationRecord
     def name_blank?
       self.name.blank?
     end
-  end
+
+    def validate_image
+      if image.blob.byte_size > MAX_IMAGE_SIZE
+        errors.add(
+          :image,
+          "ファイル サイズは 3MB 未満にする必要があります (現在のサイズは #{(image.blob.byte_size.to_f / 1.megabyte).round}MB)",
+        )
+        image.purge
+        return
+      end
+
+      unless ALLOWED_CONTENT_TYPES.include?(image.content_type)
+        errors.add(:image, "はJPEG、JPG、PNG、WebP形式のみ使用できます")
+        image.purge
+      end
+    end
 end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -87,18 +87,27 @@ class User < ApplicationRecord
       self.name.blank?
     end
 
-    def validate_image
+    def validate_image_size_and_type
       if image.blob.byte_size > MAX_IMAGE_SIZE
         errors.add(
           :image,
           "ファイル サイズは 3MB 未満にする必要があります (現在のサイズは #{(image.blob.byte_size.to_f / 1.megabyte).round}MB)",
         )
-        image.purge
-        return
+        return false
       end
 
       unless ALLOWED_CONTENT_TYPES.include?(image.content_type)
         errors.add(:image, "はJPEG、JPG、PNG、WebP形式のみ使用できます")
+        return false
+      end
+
+      true
+    end
+
+    def validate_image
+      return unless image.attached?
+
+      unless validate_image_size_and_type
         image.purge
       end
     end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable
   include DeviseTokenAuth::Concerns::User
+  before_create :set_default_name, if: :name_blank?
 
   has_many :bugs, dependent: :destroy
   has_many :comments, dependent: :destroy
@@ -33,5 +34,15 @@ class User < ApplicationRecord
 
   def following?(user)
     following.include?(user)
+  end
+  private
+
+    def set_default_name
+      self.name = SecureRandom.hex(4)
+    end
+
+    def name_blank?
+      self.name.blank?
+    end
   end
 end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable
   include DeviseTokenAuth::Concerns::User
+
   before_create :set_default_name, if: :name_blank?
 
   has_many :bugs, dependent: :destroy
@@ -16,6 +17,7 @@ class User < ApplicationRecord
   has_many :followers, through: :passive_follows, source: :follower
   has_many :likes, dependent: :destroy
   has_many :liked_bugs, through: :likes, source: :bug
+  has_one_attached :image
 
   PASSWORD_COMPLEXITY_REGEX = /\A(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,128}\z/
 
@@ -35,6 +37,18 @@ class User < ApplicationRecord
   def following?(user)
     following.include?(user)
   end
+
+  def as_json(options = {})
+    super(options.merge(
+      only: [:id, :email, :name, :nickname],
+      methods: [:image_url],
+    ))
+  end
+
+  def image_url
+    image.attached? ? Rails.application.routes.url_helpers.rails_blob_url(image) : nil
+  end
+
   private
 
     def set_default_name

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -36,6 +36,9 @@ class User < ApplicationRecord
   validates :bio, length: {
     maximum: 500,
   }, if: :profile_update?
+  validates :nickname, length: {
+    maximum: 255,
+  }, if: :profile_update?
   validates :github_url,
             length: { maximum: 255 },
             format: { with: URI::DEFAULT_PARSER.make_regexp, message: "は有効なURLではありません" },

--- a/backend/app/serializers/base_user_serializer.rb
+++ b/backend/app/serializers/base_user_serializer.rb
@@ -1,3 +1,7 @@
 class BaseUserSerializer < ActiveModel::Serializer
-  attributes :id, :name, :nickname, :image
+  attributes :id, :name, :nickname, :image_url
+
+  def image_url
+    object.image_url if object.image.attached?
+  end
 end

--- a/backend/app/serializers/current_user_serializer.rb
+++ b/backend/app/serializers/current_user_serializer.rb
@@ -1,3 +1,0 @@
-class CurrentUserSerializer < ActiveModel::Serializer
-  attributes :id, :name, :email
-end

--- a/backend/app/serializers/profile_serializer.rb
+++ b/backend/app/serializers/profile_serializer.rb
@@ -1,0 +1,3 @@
+class ProfileSerializer < BaseUserSerializer
+  attributes :bio, :github_url, :website_url
+end

--- a/backend/app/serializers/user_detail_serializer.rb
+++ b/backend/app/serializers/user_detail_serializer.rb
@@ -1,5 +1,5 @@
 class UserDetailSerializer < BaseUserSerializer
-  attributes :followers_count, :following_count, :is_following
+  attributes :bio, :github_url, :website_url, :followers_count, :following_count, :is_following
 
   def followers_count
     object.followers.count

--- a/backend/app/serializers/user_serializer.rb
+++ b/backend/app/serializers/user_serializer.rb
@@ -1,3 +1,2 @@
-class UserSerializer < ActiveModel::Serializer
-  attributes :id, :name, :nickname, :image
+class UserSerializer < BaseUserSerializer
 end

--- a/backend/config/environments/test.rb
+++ b/backend/config/environments/test.rb
@@ -61,4 +61,5 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+  config.active_storage.service_url_options = { host: "localhost", port: 3100 }
 end

--- a/backend/config/locales/ja.yml
+++ b/backend/config/locales/ja.yml
@@ -4,9 +4,15 @@ ja:
       bug: バグ
     attributes:
       user:
+        name: 名前
+        nickname: ニックネーム
+        image: 画像
         email: メールアドレス
         password: パスワード
         password_confirmation: パスワード確認用
+        github_url: GitHubのURL
+        website_url: WebサイトのURL
+        bio: 自己紹介
       bug:
         title: タイトル
         content: 内容

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
             get "liked", to: "bugs#liked"
           end
         end
+        resource :profile, only: [:show, :update]
       end
     end
   end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
         passwords: "api/v1/auth/passwords",
+        sessions: "api/v1/auth/sessions",
       }
       namespace :current do
         resource :user, only: [:show] do

--- a/backend/db/migrate/20250325095626_add_profile_details_to_users.rb
+++ b/backend/db/migrate/20250325095626_add_profile_details_to_users.rb
@@ -1,0 +1,7 @@
+class AddProfileDetailsToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :bio, :text
+    add_column :users, :github_url, :string, limit: 255
+    add_column :users, :website_url, :string, limit: 255
+  end
+end

--- a/backend/db/migrate/20250325100318_create_active_storage_tables.active_storage.rb
+++ b/backend/db/migrate/20250325100318_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [primary_key_type, foreign_key_type]
+    end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_19_125118) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_25_095626) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -113,6 +113,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_19_125118) do
     t.json "tokens"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "bio"
+    t.string "github_url", limit: 255
+    t.string "website_url", limit: 255
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_25_095626) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_25_100318) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "attempts", force: :cascade do |t|
     t.bigint "bug_id", null: false
@@ -122,6 +150,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_25_095626) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "attempts", "bugs"
   add_foreign_key "bugs", "users"
   add_foreign_key "comments", "bugs"

--- a/backend/spec/factories/users.rb
+++ b/backend/spec/factories/users.rb
@@ -6,6 +6,16 @@ FactoryBot.define do
     confirmed_at { Time.current }
     name { "テストユーザー" }
     nickname { "ニックネーム" }
-    image { "https://placehold.jp/150x150.png" }
+
+    trait :with_image do
+      after(:build) do |user|
+        file_path = Rails.root.join("spec", "fixtures", "images", "valid_image.jpg")
+        user.image.attach(
+          io: File.open(file_path),
+          filename: "valid_image.jpg",
+          content_type: "image/jpeg",
+        )
+      end
+    end
   end
 end

--- a/backend/spec/factories/users.rb
+++ b/backend/spec/factories/users.rb
@@ -6,6 +6,9 @@ FactoryBot.define do
     confirmed_at { Time.current }
     name { "テストユーザー" }
     nickname { "ニックネーム" }
+    bio { "自己紹介" }
+    github_url { "https://github.com/testuser" }
+    website_url { "https://testuser.com" }
 
     trait :with_image do
       after(:build) do |user|

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -121,6 +121,11 @@ RSpec.describe User, type: :model do
         expect(user.errors[:name]).to include("を入力してください")
       end
 
+      it "ニックネームが空の場合成功する" do
+        user.nickname = nil
+        expect(user).to be_valid
+      end
+
       it "自己紹介が空の場合成功する" do
         user.bio = nil
         expect(user).to be_valid
@@ -140,6 +145,12 @@ RSpec.describe User, type: :model do
         user.name = "a" * 256
         expect(user).to be_invalid
         expect(user.errors[:name]).to include("は255文字以内で入力してください")
+      end
+
+      it "ニックネームが255文字を超える場合失敗する" do
+        user.nickname = "a" * 256
+        expect(user).to be_invalid
+        expect(user.errors[:nickname]).to include("は255文字以内で入力してください")
       end
 
       it "自己紹介が500文字を超える場合失敗する" do

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "tempfile"
 
 RSpec.describe User, type: :model do
   let!(:user) { build(:user) }
@@ -107,6 +108,151 @@ RSpec.describe User, type: :model do
         expect(user).to be_invalid
         expect(user.errors[:password_confirmation]).to include("とパスワードの入力が一致しません")
       end
+    end
+
+    context "プロフィール更新時" do
+      before do
+        user.profile_update = true
+      end
+
+      it "名前が空の場合失敗する" do
+        user.name = nil
+        expect(user).to be_invalid
+        expect(user.errors[:name]).to include("を入力してください")
+      end
+
+      it "自己紹介が空の場合成功する" do
+        user.bio = nil
+        expect(user).to be_valid
+      end
+
+      it "Github URLが空の場合成功する" do
+        user.github_url = nil
+        expect(user).to be_valid
+      end
+
+      it "WebサイトURLが空の場合成功する" do
+        user.website_url = nil
+        expect(user).to be_valid
+      end
+
+      it "名前が255文字を超える場合失敗する" do
+        user.name = "a" * 256
+        expect(user).to be_invalid
+        expect(user.errors[:name]).to include("は255文字以内で入力してください")
+      end
+
+      it "自己紹介が500文字を超える場合失敗する" do
+        user.bio = "a" * 501
+        expect(user).to be_invalid
+        expect(user.errors[:bio]).to include("は500文字以内で入力してください")
+      end
+
+      it "Github URLが255文字を超える場合失敗する" do
+        user.github_url = "a" * 256
+        expect(user).to be_invalid
+        expect(user.errors[:github_url]).to include("は255文字以内で入力してください")
+      end
+
+      it "WebサイトURLが255文字を超える場合失敗する" do
+        user.website_url = "a" * 256
+        expect(user).to be_invalid
+        expect(user.errors[:website_url]).to include("は255文字以内で入力してください")
+      end
+
+      it "Github URLがURL形式でない場合失敗する" do
+        user.github_url = "invalid_url"
+        expect(user).to be_invalid
+        expect(user.errors[:github_url]).to include("は有効なURLではありません")
+      end
+
+      it "WebサイトURLがURL形式でない場合失敗する" do
+        user.website_url = "invalid_url"
+        expect(user).to be_invalid
+        expect(user.errors[:website_url]).to include("は有効なURLではありません")
+      end
+    end
+
+    context "トークン更新時" do
+      it "名前が空でも成功する" do
+        user.name = nil
+        expect(user).to be_valid
+      end
+    end
+  end
+
+  describe "画像のバリデーション" do
+    before do
+      user.profile_update = true
+    end
+
+    def attach_test_image(extension:, content_type:, size: 1.megabyte)
+      Tempfile.create(["test_image", ".#{extension}"]) do |file|
+        file.binmode
+        if content_type == "image/gif"
+          file.write("GIF89a")
+        else
+          file.write("\xFF\xD8\xFF\xE0") if content_type == "image/jpeg"
+          file.truncate(size)
+        end
+        file.rewind
+
+        user.image.attach(
+          io: file,
+          filename: "test_image.#{extension}",
+          content_type: content_type,
+        )
+      end
+    end
+
+    it "JPEG画像をアップロードできる" do
+      attach_test_image(extension: "jpeg", content_type: "image/jpeg")
+      expect(user).to be_valid
+    end
+
+    it "JPG画像をアップロードできる" do
+      attach_test_image(extension: "jpg", content_type: "image/jpg")
+      expect(user).to be_valid
+    end
+
+    it "PNG画像をアップロードできる" do
+      attach_test_image(extension: "png", content_type: "image/png")
+      expect(user).to be_valid
+    end
+
+    it "WebP画像をアップロードできる" do
+      attach_test_image(extension: "webp", content_type: "image/webp")
+      expect(user).to be_valid
+    end
+
+    it "画像が空の場合でも成功する" do
+      user.image = nil
+      expect(user).to be_valid
+    end
+
+    it "GIF画像をアップロードできない" do
+      attach_test_image(extension: "gif", content_type: "image/gif")
+      expect(user).to be_invalid
+      expect(user.errors[:image]).to include("はJPEG、JPG、PNG、WebP形式のみ使用できます")
+    end
+
+    it "3MBの画像はアップロードできる" do
+      attach_test_image(
+        extension: "jpg",
+        content_type: "image/jpeg",
+        size: 3.megabytes,
+      )
+      expect(user).to be_valid
+    end
+
+    it "3MBを超えるサイズの画像はアップロードできない" do
+      attach_test_image(
+        extension: "jpg",
+        content_type: "image/jpeg",
+        size: 4.megabytes,
+      )
+      expect(user).to be_invalid
+      expect(user.errors[:image]).to include("ファイル サイズは 3MB 未満にする必要があります (現在のサイズは 4MB)")
     end
   end
 end

--- a/backend/spec/requests/api/v1/mypage/profile_spec.rb
+++ b/backend/spec/requests/api/v1/mypage/profile_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Mypage::Profile", type: :request do
+  let(:user) { create(:user) }
+  let(:headers) { user.create_new_auth_token }
+  let(:valid_params) do
+    {
+      name: "New Name",
+      nickname: "New Nickname",
+      bio: "New Bio",
+      github_url: "https://github.com/newuser",
+      website_url: "https://example.com",
+    }
+  end
+  let(:invalid_params) do
+    {
+      name: "a" * 256,
+      nickname: "a" * 256,
+      bio: "a" * 501,
+      github_url: "invalid-url",
+      website_url: "invalid-url",
+    }
+  end
+
+  describe "GET /api/v1/mypage/profile" do
+    context "ログインしている場合" do
+      it "プロフィールの情報を取得できる" do
+        get api_v1_mypage_profile_path, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response_json).to include(
+          "name" => user.name,
+          "nickname" => user.nickname,
+          "bio" => user.bio,
+          "github_url" => user.github_url,
+          "website_url" => user.website_url,
+          "image_url" => user.image_url,
+        )
+      end
+    end
+
+    context "ログインしていない場合" do
+      it "認証エラーが発生すること" do
+        get api_v1_mypage_profile_path
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "PATCH /api/v1/mypage/profile" do
+    context "ログインしている場合" do
+      context "正しい値が入力された場合" do
+        it "プロフィールの情報の更新が成功する" do
+          patch api_v1_mypage_profile_path, params: valid_params, headers: headers
+
+          expect(response).to have_http_status(:ok)
+          expect(response_json["message"]).to eq("プロフィールを更新しました")
+
+          user.reload
+          expect(user.name).to eq(valid_params[:name])
+          expect(user.nickname).to eq(valid_params[:nickname])
+          expect(user.bio).to eq(valid_params[:bio])
+          expect(user.github_url).to eq(valid_params[:github_url])
+          expect(user.website_url).to eq(valid_params[:website_url])
+        end
+      end
+
+      context "間違った値が入力された場合" do
+        it "プロフィールの情報の更新が失敗する" do
+          patch api_v1_mypage_profile_path, params: invalid_params, headers: headers
+
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+
+    context "ログインしていない場合" do
+      it "認証エラーが発生すること" do
+        patch api_v1_mypage_profile_path, params: valid_params
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/users_spec.rb
+++ b/backend/spec/requests/api/v1/users_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Api::V1::Users", type: :request do
       expect(response).to have_http_status(:ok)
       expect(response_json["id"]).to eq(user.id)
       expect(response_json["name"]).to eq(user.name)
-      expect(response_json["image"]).to eq(user.image)
+      expect(response_json["image_url"]).to eq(user.image_url)
       expect(response_json["nickname"]).to eq(user.nickname)
     end
 

--- a/frontend/src/__tests__/components/layouts/Header.test.tsx
+++ b/frontend/src/__tests__/components/layouts/Header.test.tsx
@@ -42,7 +42,7 @@ describe('Header', () => {
     render(
       <AuthContext.Provider
         value={{
-          currentUser: { id: 1, name: 'Test User', email: 'test@example.com' },
+          currentUser: { id: 1, name: 'Test User', imageUrl: 'test.com' },
           isAuthenticated: true,
           isFetched: true,
           setCurrentUser: jest.fn(),
@@ -55,7 +55,6 @@ describe('Header', () => {
     )
 
     expect(screen.getByText('マイページ')).toBeInTheDocument()
-    expect(screen.getByText('設定')).toBeInTheDocument()
     expect(screen.getByText('ログアウト')).toBeInTheDocument()
   })
 
@@ -71,7 +70,7 @@ describe('Header', () => {
     render(
       <AuthContext.Provider
         value={{
-          currentUser: { id: 1, name: 'Test User', email: 'test@example.com' },
+          currentUser: { id: 1, name: 'Test User', imageUrl: 'test.com' },
           isAuthenticated: true,
           isFetched: true,
           setCurrentUser: jest.fn(),

--- a/frontend/src/__tests__/pages/auth/confirmation.test.tsx
+++ b/frontend/src/__tests__/pages/auth/confirmation.test.tsx
@@ -5,6 +5,9 @@ import { toast } from 'react-toastify'
 import Confirmation from '@/pages/auth/confirmation'
 import { AuthProvider } from '@/providers/AuthProvider'
 
+jest.mock('@/utils', () => ({
+  fetcher: jest.fn(),
+}))
 jest.mock('axios')
 jest.mock('next/router', () => ({
   useRouter: jest.fn(),

--- a/frontend/src/__tests__/pages/auth/email-sent.test.tsx
+++ b/frontend/src/__tests__/pages/auth/email-sent.test.tsx
@@ -2,6 +2,10 @@ import { render, screen } from '@testing-library/react'
 import EmailSent from '@/pages/auth/email-sent'
 import { AuthProvider } from '@/providers/AuthProvider'
 
+jest.mock('@/utils', () => ({
+  fetcher: jest.fn(),
+}))
+
 jest.mock('next/router', () => ({
   useRouter: jest.fn(),
 }))

--- a/frontend/src/__tests__/providers/AuthProvider.test.tsx
+++ b/frontend/src/__tests__/providers/AuthProvider.test.tsx
@@ -1,20 +1,20 @@
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
-import axios from 'axios'
 import { useRouter } from 'next/router'
 import { useContext } from 'react'
 import { toast } from 'react-toastify'
 import { AuthContext } from '@/context/AuthContext'
 import { AuthProvider } from '@/providers/AuthProvider'
+import { fetcher } from '@/utils'
 import { API_URLS } from '@/utils/api'
-import { getAuthHeaders } from '@/utils/headers'
 
-jest.mock('axios')
+jest.mock('@/utils', () => ({
+  fetcher: jest.fn(),
+}))
 jest.mock('react-toastify', () => ({
   toast: {
     success: jest.fn(),
   },
 }))
-
 jest.mock('next/router', () => ({
   useRouter: jest.fn(),
 }))
@@ -54,7 +54,7 @@ describe('AuthProvider', () => {
 
   it('localStorage に認証情報がある場合 fetchCurrentUser が呼ばれること', async () => {
     const mockUser = { id: 1, name: 'Test User', email: 'test@example.com' }
-    ;(axios.get as jest.Mock).mockResolvedValue({ data: mockUser })
+    ;(fetcher as jest.Mock).mockResolvedValue(mockUser)
 
     localStorage.setItem('access-token', 'test-token')
     localStorage.setItem('client', 'test-client')
@@ -78,9 +78,7 @@ describe('AuthProvider', () => {
     )
 
     await waitFor(() => {
-      expect(axios.get).toHaveBeenCalledWith(API_URLS.AUTH.CURRENT_USER, {
-        headers: getAuthHeaders(),
-      })
+      expect(fetcher).toHaveBeenCalledWith(API_URLS.AUTH.CURRENT_USER)
     })
 
     expect(

--- a/frontend/src/components/MypageLayout.tsx
+++ b/frontend/src/components/MypageLayout.tsx
@@ -12,9 +12,13 @@ export const MypageLayout = ({ children }: { children: ReactNode }) => {
   return (
     <div className="flex min-h-screen flex-col bg-base-200">
       <Header />
-      <div className="flex flex-1 p-6">
-        <div className="w-64 rounded-md bg-white p-4 shadow-lg">
-          <ul className="menu p-2 font-bold">
+      <div className="flex flex-1 flex-col gap-6 p-6 md:flex-row">
+        <main className="w-full md:order-2 md:max-w-5xl lg:max-w-6xl">
+          {children}
+        </main>
+
+        <div className="w-full rounded-md bg-white p-4 shadow-lg md:order-1 md:w-64">
+          <ul className="menu flex flex-col p-2 font-bold">
             <li className={isActive('/mypage') ? 'text-primary' : ''}>
               <Link href="/mypage">バグ</Link>
             </li>
@@ -22,7 +26,7 @@ export const MypageLayout = ({ children }: { children: ReactNode }) => {
               <Link href="/mypage/follows">フォロー・フォロワー</Link>
             </li>
             <li className={isActive('/mypage/profile') ? 'text-primary' : ''}>
-              <Link href="">プロフィール</Link>
+              <Link href="/mypage/profile">プロフィール</Link>
             </li>
             <li
               className={
@@ -43,10 +47,6 @@ export const MypageLayout = ({ children }: { children: ReactNode }) => {
             </li>
           </ul>
         </div>
-
-        <main className="mx-auto flex-1 p-4 md:max-w-4xl lg:max-w-3xl">
-          {children}
-        </main>
       </div>
       <Footer />
     </div>

--- a/frontend/src/components/layouts/Header.tsx
+++ b/frontend/src/components/layouts/Header.tsx
@@ -30,11 +30,14 @@ export const Header = () => {
                   >
                     <div className="w-10 rounded-full">
                       <Image
-                        src={currentUser?.image || '/images/default-avatar.png'}
+                        src={
+                          currentUser?.imageUrl || '/images/default-avatar.png'
+                        }
                         alt="User Avatar"
                         width={40}
                         height={40}
                         className="rounded-full"
+                        unoptimized
                       />
                     </div>
                   </div>
@@ -43,12 +46,14 @@ export const Header = () => {
                     className="menu dropdown-content rounded-box menu-sm z-[1] mt-3 w-52 bg-base-100 p-2 shadow"
                   >
                     <li>
+                      <span className="border-b font-bold">
+                        {currentUser?.name}
+                      </span>
+                    </li>
+                    <li>
                       <Link href="/mypage" className="justify-between">
                         マイページ
                       </Link>
-                    </li>
-                    <li>
-                      <a>設定</a>
                     </li>
                     <li>
                       <button onClick={signout}>ログアウト</button>

--- a/frontend/src/features/auth/components/AccountDeleteForm.tsx
+++ b/frontend/src/features/auth/components/AccountDeleteForm.tsx
@@ -24,7 +24,7 @@ export const AccountDeleteForm = ({
   isLoading,
 }: AccountDeleteFormProps) => {
   return (
-    <div className="mt-10 flex justify-center">
+    <div className="flex justify-center">
       <div className="w-96 rounded-lg bg-white p-6 shadow-lg">
         <FormHeading
           title="アカウント削除"

--- a/frontend/src/features/auth/ui/FormField.tsx
+++ b/frontend/src/features/auth/ui/FormField.tsx
@@ -9,7 +9,7 @@ import {
 type FormFieldProps<T extends FieldValues> = {
   label: string
   name: Path<T>
-  type: 'text' | 'email' | 'password'
+  type: 'text' | 'email' | 'password' | 'textarea'
   register: UseFormRegister<T>
   errors: FieldErrors<T>
   placeholder?: string
@@ -28,13 +28,22 @@ export const FormField = <T extends FieldValues>({
       <label htmlFor={name as string} className="label">
         <span className="label-text">{label}</span>
       </label>
-      <input
-        id={name as string}
-        type={type}
-        {...register(name)}
-        className="input input-bordered w-full"
-        placeholder={placeholder}
-      />
+      {type === 'textarea' ? (
+        <textarea
+          id={name as string}
+          {...register(name)}
+          className="textarea textarea-bordered h-24 w-full"
+          placeholder={placeholder}
+        />
+      ) : (
+        <input
+          id={name as string}
+          type={type}
+          {...register(name)}
+          className="input input-bordered w-full"
+          placeholder={placeholder}
+        />
+      )}
       {errors[name] && (
         <p className="mt-1 text-sm text-red-500">
           {(errors[name] as FieldError)?.message}

--- a/frontend/src/features/auth/ui/FormField.tsx
+++ b/frontend/src/features/auth/ui/FormField.tsx
@@ -12,7 +12,7 @@ type FormFieldProps<T extends FieldValues> = {
   type: 'text' | 'email' | 'password'
   register: UseFormRegister<T>
   errors: FieldErrors<T>
-  placeholder: string
+  placeholder?: string
 }
 
 export const FormField = <T extends FieldValues>({

--- a/frontend/src/features/bugs/types/Bug.ts
+++ b/frontend/src/features/bugs/types/Bug.ts
@@ -23,7 +23,7 @@ export type Bug = {
   fromToday: string
   user: {
     id: number
-    image: string
+    imageUrl: string
     name: string
     nickname: string
   }

--- a/frontend/src/features/bugs/types/BugListItem.tsx
+++ b/frontend/src/features/bugs/types/BugListItem.tsx
@@ -9,6 +9,7 @@ export type BugListItem = {
   user: {
     id: number
     nickname: string
-    image: string
+    imageUrl: string
+    name: string
   }
 }

--- a/frontend/src/features/bugs/ui/BugListItem.tsx
+++ b/frontend/src/features/bugs/ui/BugListItem.tsx
@@ -40,10 +40,11 @@ export const BugListItem = ({
               <div className="avatar">
                 <div className="size-10 rounded-full">
                   <Image
-                    src={user.image || '/images/default-avatar.png'}
+                    src={user.imageUrl || '/images/default-avatar.png'}
                     alt="User Avatar"
                     width={20}
                     height={20}
+                    unoptimized
                   />
                 </div>
               </div>

--- a/frontend/src/features/comment/types/Comment.ts
+++ b/frontend/src/features/comment/types/Comment.ts
@@ -5,7 +5,7 @@ export type Comment = {
   createdAt: string
   user: {
     id: number
-    image: string
+    imageUrl: string
     nickname: string
   }
 }

--- a/frontend/src/features/comment/ui/Comment.tsx
+++ b/frontend/src/features/comment/ui/Comment.tsx
@@ -26,7 +26,7 @@ export const Comment = ({ comment, onDelete }: CommentProps) => {
         {!isCurrentUser && (
           <Link href={`/users/${comment.user.id}`}>
             <Image
-              src={comment.user?.image || '/images/default-avatar.png'}
+              src={comment.user?.imageUrl || '/images/default-avatar.png'}
               alt={comment.user?.nickname || 'User Avatar'}
               width={30}
               height={30}
@@ -48,11 +48,12 @@ export const Comment = ({ comment, onDelete }: CommentProps) => {
         {isCurrentUser && (
           <Link href={`/users/${comment.user.id}`}>
             <Image
-              src={comment.user?.image || '/images/default-avatar.png'}
+              src={comment.user?.imageUrl || '/images/default-avatar.png'}
               alt={comment.user?.nickname || 'User Avatar'}
               width={30}
               height={30}
               className="rounded-full"
+              unoptimized
             />
           </Link>
         )}

--- a/frontend/src/features/mypage/components/PasswordChangeForm.tsx
+++ b/frontend/src/features/mypage/components/PasswordChangeForm.tsx
@@ -8,7 +8,7 @@ import { FormField } from '@/features/auth/ui/FormField'
 import { FormHeading } from '@/features/auth/ui/FormHeading'
 import { SubmitButton } from '@/features/auth/ui/SubmitButton'
 
-type AccountDeleteFormProps = {
+type PasswordChangeFormProps = {
   register: UseFormRegister<ChangePasswordFormValues>
   handleSubmit: UseFormHandleSubmit<ChangePasswordFormValues>
   errors: FieldErrors<ChangePasswordFormValues>
@@ -22,7 +22,7 @@ export const PasswordChangeForm = ({
   errors,
   onSubmit,
   isLoading,
-}: AccountDeleteFormProps) => {
+}: PasswordChangeFormProps) => {
   return (
     <div className="mt-10 flex justify-center">
       <div className="w-96 rounded-lg bg-white p-6 shadow-lg">

--- a/frontend/src/features/mypage/components/PasswordChangeForm.tsx
+++ b/frontend/src/features/mypage/components/PasswordChangeForm.tsx
@@ -24,7 +24,7 @@ export const PasswordChangeForm = ({
   isLoading,
 }: PasswordChangeFormProps) => {
   return (
-    <div className="mt-10 flex justify-center">
+    <div className="flex justify-center">
       <div className="w-96 rounded-lg bg-white p-6 shadow-lg">
         <FormHeading title="パスワード変更" />
         <form

--- a/frontend/src/features/mypage/components/ProfileForm.tsx
+++ b/frontend/src/features/mypage/components/ProfileForm.tsx
@@ -1,0 +1,116 @@
+import Image from 'next/image'
+import { useState } from 'react'
+import {
+  UseFormRegister,
+  FieldErrors,
+  UseFormHandleSubmit,
+  UseFormSetValue,
+} from 'react-hook-form'
+import { ProfileFormValues } from '../validations/updateProfileValidation'
+import { FormField } from '@/features/auth/ui/FormField'
+import { FormHeading } from '@/features/auth/ui/FormHeading'
+import { SubmitButton } from '@/features/auth/ui/SubmitButton'
+
+type ProfileFormProps = {
+  register: UseFormRegister<ProfileFormValues>
+  handleSubmit: UseFormHandleSubmit<ProfileFormValues>
+  setValue: UseFormSetValue<ProfileFormValues>
+  errors: FieldErrors<ProfileFormValues>
+  onSubmit: (data: ProfileFormValues) => void
+  isLoading: boolean
+  imageUrl: string
+}
+
+export const ProfileForm = ({
+  register,
+  handleSubmit,
+  setValue,
+  errors,
+  onSubmit,
+  isLoading,
+  imageUrl,
+}: ProfileFormProps) => {
+  const [imagePreview, setImagePreview] = useState(imageUrl || '')
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) {
+      setImagePreview(URL.createObjectURL(file))
+      setValue('image', file)
+    }
+  }
+
+  return (
+    <div className="flex justify-center">
+      <div className="w-96 rounded-lg bg-white p-6 shadow-lg">
+        <FormHeading title="プロフィール" />
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          className="space-y-4"
+          role="form"
+        >
+          <div className="flex flex-col items-center">
+            <div className="relative mt-2 flex size-24 cursor-pointer items-center justify-center overflow-hidden rounded-full">
+              <Image
+                src={imagePreview ? imagePreview : '/images/default-avatar.png'}
+                alt="Profile Preview"
+                className="size-full object-cover"
+                width={96}
+                height={96}
+                unoptimized
+              />
+              <input
+                type="file"
+                accept="image/jpeg,image/jpg,image/png"
+                onChange={handleImageChange}
+                className="absolute inset-0 size-full cursor-pointer opacity-0"
+              />
+            </div>
+            {errors.image && (
+              <p className="mt-1 text-sm text-red-500">
+                {errors.image.message}
+              </p>
+            )}
+          </div>
+          <FormField
+            label="名前"
+            name="name"
+            type="text"
+            register={register}
+            errors={errors}
+          />
+          <FormField
+            label="ニックネーム"
+            name="nickname"
+            type="text"
+            register={register}
+            errors={errors}
+          />
+          <FormField
+            label="自己紹介"
+            name="bio"
+            type="textarea"
+            register={register}
+            errors={errors}
+          />
+          <FormField
+            label="Github"
+            name="githubUrl"
+            type="text"
+            register={register}
+            errors={errors}
+          />
+          <FormField
+            label="Web"
+            name="websiteUrl"
+            type="text"
+            register={register}
+            errors={errors}
+          />
+
+          <SubmitButton text="更新" isLoading={isLoading} />
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/mypage/validations/updateProfileValidation.ts
+++ b/frontend/src/features/mypage/validations/updateProfileValidation.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod'
+
+const IMAGE_SIZE_LIMIT = 3 * 1024 * 1024
+const ACCEPTED_IMAGE_TYPES = [
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/webp',
+]
+
+export const updateProfileSchema = z.object({
+  image: z
+    .custom<File>()
+    .optional()
+    .refine(
+      (file) => {
+        if (!file) return true
+        return file.size <= IMAGE_SIZE_LIMIT
+      },
+      {
+        message: 'ファイル サイズは 3MB 以内にしてください',
+      },
+    )
+    .refine((file) => !file || ACCEPTED_IMAGE_TYPES.includes(file.type), {
+      message: '画像は JPEG, JPG, PNG, WebP のみアップロードできます',
+    }),
+  name: z
+    .string()
+    .min(1, { message: '名前は必須です' })
+    .max(255, { message: '名前は255文字以下で入力してください' }),
+  nickname: z
+    .string()
+    .max(255, { message: 'ニックネームは255文字以下で入力してください' }),
+  bio: z
+    .string()
+    .max(500, { message: '自己紹介は500文字以下で入力してください' }),
+  githubUrl: z
+    .string()
+    .url({ message: '正しいURLを入力してください' })
+    .optional()
+    .or(z.literal('')),
+  websiteUrl: z
+    .string()
+    .url({ message: '正しいURLを入力してください' })
+    .optional()
+    .or(z.literal('')),
+})
+
+export type ProfileFormValues = z.infer<typeof updateProfileSchema>

--- a/frontend/src/features/user/components/FollowListItem.tsx
+++ b/frontend/src/features/user/components/FollowListItem.tsx
@@ -22,11 +22,12 @@ export const FollowListItem = ({
     <li className="mb-4 flex h-[64px] items-center justify-between rounded-md bg-base-100 p-4 shadow-xl">
       <div className="flex grow items-center">
         <Image
-          src={user.image || '/images/default-avatar.png'}
+          src={user.imageUrl || '/images/default-avatar.png'}
           alt={user.name}
           width={40}
           height={40}
           className="mr-4 rounded-full"
+          unoptimized
         />
         <Link href={`/users/${user.id}`} className="text-sm font-medium">
           {user.name || 'aaaaaaaaaaaaaaa'}

--- a/frontend/src/pages/bugs/[id].tsx
+++ b/frontend/src/pages/bugs/[id].tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import axios from 'axios'
+import Image from 'next/image'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
@@ -165,7 +166,7 @@ const BugDetail = () => {
               {currentUser?.id === bug.user.id && (
                 <BugStatus isSolved={bug.isSolved} status={bug.status} />
               )}
-              <p className="text-sm text-gray-500">{`${bug?.fromToday} に投稿`}</p>
+              <p className="text-right text-sm text-gray-500">{`${bug?.fromToday} に投稿`}</p>
               <h2 className="card-title text-3xl">{bug?.title}</h2>
               <div className="my-4 space-y-20">
                 <EnvironmentTable environments={bug?.environments || []} />
@@ -208,8 +209,32 @@ const BugDetail = () => {
                 <BugSection title="その他" content={bug?.etc} />
               </div>
 
-              <div className="mt-4 text-sm text-gray-500">
-                {`作成者: ${bug?.user.nickname}`}
+              <div className="mt-4 flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <Link href={`/users/${bug.user.id}`}>
+                    <Image
+                      src={bug.user.imageUrl || '/images/default-avatar.png'}
+                      alt={`${bug.user.nickname}のアバター`}
+                      width={40}
+                      height={40}
+                      className="rounded-full"
+                      unoptimized
+                    />
+                  </Link>
+                  <Link
+                    href={`/users/${bug.user.id}`}
+                    className="text-sm text-gray-600 hover:text-gray-900 hover:underline"
+                  >
+                    {bug.user.nickname}
+                  </Link>
+                </div>
+                <LikeButton
+                  bugId={bug.id}
+                  likeCount={bug.likeCount}
+                  isLiked={bug.isLiked}
+                  isLoading={likeMutation.isPending}
+                  onToggleLike={handleToggleLike}
+                />
               </div>
 
               {bug?.user.id === currentUser?.id && (
@@ -225,13 +250,6 @@ const BugDetail = () => {
                   </button>
                 </div>
               )}
-              <LikeButton
-                bugId={bug.id}
-                likeCount={bug.likeCount}
-                isLiked={bug.isLiked}
-                isLoading={likeMutation.isPending}
-                onToggleLike={handleToggleLike}
-              />
             </div>
           </div>
           <div className="card mt-6 bg-base-100 shadow-lg">

--- a/frontend/src/pages/mypage/profile.tsx
+++ b/frontend/src/pages/mypage/profile.tsx
@@ -1,0 +1,128 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import axios, { AxiosError } from 'axios'
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
+import { SubmitHandler, useForm } from 'react-hook-form'
+import { toast } from 'react-toastify'
+import { Profile as ProfileType } from './types/Profile'
+import { MypageLayout } from '@/components/MypageLayout'
+import { Loading } from '@/components/utilities/Loading'
+import { ProfileForm } from '@/features/mypage/components/ProfileForm'
+import {
+  ProfileFormValues,
+  updateProfileSchema,
+} from '@/features/mypage/validations/updateProfileValidation'
+import { useRequiredSignedIn } from '@/hooks/useRequiredSignedIn'
+import { fetcher } from '@/utils'
+import { API_URLS } from '@/utils/api'
+import { getAuthHeaders } from '@/utils/headers'
+
+const Profile = () => {
+  useRequiredSignedIn()
+  const router = useRouter()
+  const queryClient = useQueryClient()
+
+  const { data, isPending: isProfilePending } = useQuery<ProfileType>({
+    queryKey: ['profile'],
+    queryFn: () => fetcher(API_URLS.MYPAGE.PROFILE.SHOW),
+  })
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    setValue,
+    formState: { errors },
+  } = useForm<ProfileFormValues>({
+    defaultValues: {
+      name: '',
+      nickname: '',
+      bio: '',
+      githubUrl: '',
+      websiteUrl: '',
+    },
+    resolver: zodResolver(updateProfileSchema),
+  })
+
+  useEffect(() => {
+    if (data) {
+      const profile: ProfileFormValues = {
+        name: data.name || '',
+        nickname: data.nickname || '',
+        bio: data.bio || '',
+        githubUrl: data.githubUrl || '',
+        websiteUrl: data.websiteUrl || '',
+      }
+      reset(profile)
+    }
+  }, [data, reset])
+
+  const updateProfile = async (data: ProfileFormValues) => {
+    const formData = new FormData()
+    formData.append('name', data.name)
+    formData.append('nickname', data.nickname || '')
+    formData.append('bio', data.bio || '')
+    formData.append('github_url', data.githubUrl || '')
+    formData.append('website_url', data.websiteUrl || '')
+
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]')
+    if (fileInput?.files?.[0]) {
+      formData.append('image', fileInput.files[0])
+    }
+
+    const response = await axios.patch(
+      API_URLS.MYPAGE.PROFILE.UPDATE,
+      formData,
+      {
+        headers: {
+          ...(getAuthHeaders() ?? {}),
+          'Content-Type': 'multipart/form-data',
+        },
+      },
+    )
+    return response
+  }
+
+  const updateProfileMutation = useMutation({
+    mutationFn: updateProfile,
+    onSuccess: (response) => {
+      toast.success(response.data.message)
+      queryClient.invalidateQueries({ queryKey: ['profile'] })
+      router.push('/mypage')
+    },
+    onError: (error: AxiosError<{ errors: string[] }>) => {
+      console.log(error)
+      const errorMessage =
+        error.response?.data?.errors[0] || '予期しないエラーが発生しました'
+      toast.error(errorMessage)
+    },
+  })
+
+  const onSubmit: SubmitHandler<ProfileFormValues> = (
+    data: ProfileFormValues,
+  ) => {
+    updateProfileMutation.mutate(data)
+  }
+
+  return (
+    <MypageLayout>
+      {isProfilePending ? (
+        <Loading />
+      ) : (
+        <ProfileForm
+          register={register}
+          handleSubmit={handleSubmit}
+          errors={errors}
+          onSubmit={onSubmit}
+          isLoading={updateProfileMutation.isPending}
+          imageUrl={data?.imageUrl ?? ''}
+          setValue={setValue}
+        />
+      )}
+    </MypageLayout>
+  )
+}
+
+export default Profile

--- a/frontend/src/pages/mypage/types/Profile.ts
+++ b/frontend/src/pages/mypage/types/Profile.ts
@@ -1,0 +1,8 @@
+export type Profile = {
+  name: string
+  nickname?: string
+  bio?: string
+  githubUrl?: string
+  websiteUrl?: string
+  imageUrl?: string
+}

--- a/frontend/src/pages/users/[id].tsx
+++ b/frontend/src/pages/users/[id].tsx
@@ -113,8 +113,11 @@ const UserDetail = () => {
                 priority
                 unoptimized
               />
-              <div>
+              <div className="flex-1">
                 <h1 className="text-3xl font-bold">{user?.name}</h1>
+                {user?.nickname && (
+                  <p className="mt-1 text-gray-600">{user.nickname}</p>
+                )}
                 <div className="mt-4 text-right">
                   {currentUser?.id !== user?.id && user && (
                     <FollowButton
@@ -125,6 +128,57 @@ const UserDetail = () => {
                     />
                   )}
                 </div>
+              </div>
+            </div>
+
+            <div className="mt-6 space-y-4">
+              {user?.bio && (
+                <div className="whitespace-pre-wrap rounded-lg bg-white p-4 shadow">
+                  {user.bio}
+                </div>
+              )}
+
+              <div className="flex flex-wrap gap-4">
+                {user?.githubUrl && (
+                  <a
+                    href={user.githubUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-2 text-gray-600 hover:text-gray-900"
+                  >
+                    <svg
+                      className="size-5"
+                      fill="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+                    </svg>
+                    GitHub
+                  </a>
+                )}
+                {user?.websiteUrl && (
+                  <a
+                    href={user.websiteUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-2 text-gray-600 hover:text-gray-900"
+                  >
+                    <svg
+                      className="size-5"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="2"
+                        d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"
+                      />
+                    </svg>
+                    Website
+                  </a>
+                )}
               </div>
             </div>
 

--- a/frontend/src/pages/users/[id].tsx
+++ b/frontend/src/pages/users/[id].tsx
@@ -105,12 +105,13 @@ const UserDetail = () => {
           <div className="mx-auto max-w-xl">
             <div className="flex items-center gap-4">
               <Image
-                src={user?.image || '/images/default-avatar.png'}
+                src={user?.imageUrl || '/images/default-avatar.png'}
                 alt={user?.name || 'User Avatar'}
                 width={96}
                 height={96}
                 className="rounded-full"
                 priority
+                unoptimized
               />
               <div>
                 <h1 className="text-3xl font-bold">{user?.name}</h1>

--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -1,11 +1,10 @@
-import axios from 'axios'
 import { useRouter } from 'next/router'
 import { ReactNode, useEffect, useState } from 'react'
 import { toast } from 'react-toastify'
 import { AuthContext } from '@/context/AuthContext'
 import { CurrentUser } from '@/types/CurrentUser'
+import { fetcher } from '@/utils'
 import { API_URLS } from '@/utils/api'
-import { getAuthHeaders } from '@/utils/headers'
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const router = useRouter()
@@ -15,11 +14,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   const fetchCurrentUser = async () => {
     try {
-      const response = await axios.get(API_URLS.AUTH.CURRENT_USER, {
-        headers: getAuthHeaders() ?? {},
-      })
-
-      setCurrentUser(response.data)
+      const data = await fetcher(API_URLS.AUTH.CURRENT_USER)
+      setCurrentUser(data)
       setIsAuthenticated(true)
       setIsFetched(true)
     } catch (error) {

--- a/frontend/src/types/CurrentUser.ts
+++ b/frontend/src/types/CurrentUser.ts
@@ -1,6 +1,5 @@
 export type CurrentUser = {
   id: number
   name: string
-  image: string
-  email: string
+  imageUrl: string
 } | null

--- a/frontend/src/types/User.ts
+++ b/frontend/src/types/User.ts
@@ -2,6 +2,9 @@ export type User = {
   id: number
   name: string
   nickname: string
+  bio: string
+  githubUrl: string
+  websiteUrl: string
   imageUrl: string
   isFollowing: boolean
 }

--- a/frontend/src/types/User.ts
+++ b/frontend/src/types/User.ts
@@ -2,6 +2,6 @@ export type User = {
   id: number
   name: string
   nickname: string
-  image: string
+  imageUrl: string
   isFollowing: boolean
 }

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -46,5 +46,9 @@ export const API_URLS = {
       const filterValue = filter === 'all' ? '' : filter
       return `${process.env.NEXT_PUBLIC_API_URL}/mypage/bugs${filterValue ? `/${filterValue}` : ''}?page=${page}`
     },
+    PROFILE: {
+      SHOW: `${process.env.NEXT_PUBLIC_API_URL}/mypage/profile`,
+      UPDATE: `${process.env.NEXT_PUBLIC_API_URL}/mypage/profile`,
+    },
   },
 }


### PR DESCRIPTION
## 概要

プロフィール編集機能実装

## 関連するissue番号

- #12 
- #75 

## 行ったこと

- 新規登録時にユーザー名を自動で生成
- プロフィール取得・編集API作成
- Active Storage導入
- プロフィールデータ、画像のバリデーションのモデルスペック作成
- プロフィール取得・編集APIのリクエストスペック作成
- プロフィールページコンポーネント作成
- プロフィール取得・編集APIリクエスト作成
- マイページレスポンシブ対応
- アバター画像の表示

## 動作確認

フロントエンド http://localhost:8080/mypage/profile
バックエンド http://localhost:3100/api/v1/mypage/profile

## その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new profile management section where users can view and update details such as name, nickname, bio, GitHub URL, website URL, and profile image with enhanced upload validations.
  - Enhanced user detail pages and header displays to include updated avatars and social links.
  - Expanded Japanese localization for user profile attributes.
  - Added a new `ProfileForm` component for user profile updates with image upload support.
  - Implemented a new `updateProfileSchema` for validating profile updates.

- **Bug Fixes**
  - Corrected image source references in various components to use `imageUrl` instead of `image`.

- **Chores**
  - Updated API URLs for profile management in the utility functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->