### PR TITLE
通知機能実装

### DIFF
--- a/backend/app/controllers/api/v1/mypage/notifications_controller.rb
+++ b/backend/app/controllers/api/v1/mypage/notifications_controller.rb
@@ -1,0 +1,43 @@
+class Api::V1::Mypage::NotificationsController < Api::V1::BaseController
+  include Pagination
+
+  before_action :authenticate_user!
+
+  def index
+    notifications = current_user.notifications.
+                      includes(:notifiable, :actor, notifiable: { comment: [:user] }).
+                      filter_by_tab(params[:tab]).
+                      recent.
+                      page(params[:page]).per(10)
+
+    render json: notifications, each_serializer: NotificationSerializer, status: :ok, meta: pagination(notifications), adapter: :json
+  end
+
+  def header
+    notifications = current_user.notifications.
+                      includes(:notifiable, :actor, notifiable: { comment: [:user] }).
+                      recent.
+                      limit(5)
+    render json: notifications, each_serializer: NotificationSerializer, status: :ok
+  end
+
+  def update
+    notification = current_user.notifications.find(params[:id])
+
+    if notification.update(read: true)
+      head :no_content
+    else
+      render json: { errors: notification.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    notification = current_user.notifications.find(params[:id])
+
+    if notification.destroy
+      head :no_content
+    else
+      render json: { errors: notification.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+end

--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::UsersController < Api::V1::BaseController
 
   def bugs
     user = find_user
-    bugs = user.bugs.where(status: "published").order(created_at: :desc).page(params[:page] || 1).per(10)
+    bugs = user.bugs.published.newest.includes(:tags).page(params[:page] || 1).per(10)
     render json: bugs, each_serializer: BugListSerializer, status: :ok, meta: pagination(bugs), adapter: :json
   end
 

--- a/backend/app/models/bug.rb
+++ b/backend/app/models/bug.rb
@@ -16,7 +16,7 @@ class Bug < ApplicationRecord
   scope :newest, -> { order(created_at: :desc) }
   scope :oldest, -> { order(created_at: :asc) }
 
-  after_create :create_notification_for_published_bug
+  before_save :create_notification_for_published_bug, if: :status_changed_to_published?
 
   def self.search(params)
     bugs = published.includes(:tags, user: { image_attachment: :blob })
@@ -57,9 +57,11 @@ class Bug < ApplicationRecord
 
   private
 
-    def create_notification_for_published_bug
-      return unless status == "published"
+    def status_changed_to_published?
+      status_changed? && status == "published"
+    end
 
+    def create_notification_for_published_bug
       create_notifications_for_followers("published")
     end
 end

--- a/backend/app/models/comment.rb
+++ b/backend/app/models/comment.rb
@@ -1,6 +1,16 @@
 class Comment < ApplicationRecord
+  include Notifiable
+
   belongs_to :user
   belongs_to :bug
 
   validates :content, presence: true, length: { maximum: 1000 }
+
+  after_create :create_notification_for_comment
+
+  private
+
+    def create_notification_for_comment
+      create_notification(bug.user, "commented", user)
+    end
 end

--- a/backend/app/models/concerns/notifiable.rb
+++ b/backend/app/models/concerns/notifiable.rb
@@ -1,0 +1,33 @@
+module Notifiable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :notifications, as: :notifiable, dependent: :destroy
+  end
+
+  def create_notification(user, action, actor = nil)
+    return if user == self.user
+
+    Notification.create!(
+      user: user,
+      actor: actor || self.user,
+      notifiable: self,
+      action: action,
+    )
+  end
+
+  def create_notifications_for_followers(action)
+    return unless respond_to?(:user) && user.respond_to?(:followers)
+
+    user.followers.find_each do |follower|
+      next if follower == self.user
+
+      Notification.create!(
+        user: follower,
+        actor: self.user,
+        notifiable: self,
+        action: action,
+      )
+    end
+  end
+end

--- a/backend/app/models/follow.rb
+++ b/backend/app/models/follow.rb
@@ -4,4 +4,17 @@ class Follow < ApplicationRecord
 
   validates :follower_id, presence: true
   validates :followed_id, presence: true
+
+  after_create :create_notification_for_follow
+
+  private
+
+    def create_notification_for_follow
+      Notification.create!(
+        user: followed,
+        actor: follower,
+        notifiable: self,
+        action: "followed",
+      )
+    end
 end

--- a/backend/app/models/like.rb
+++ b/backend/app/models/like.rb
@@ -1,4 +1,16 @@
 class Like < ApplicationRecord
+  include Notifiable
+
   belongs_to :user
   belongs_to :bug, counter_cache: true
+
+  validates :user_id, uniqueness: { scope: :bug_id }
+
+  after_create :create_notification_for_like
+
+  private
+
+    def create_notification_for_like
+      create_notification(bug.user, "liked", user)
+    end
 end

--- a/backend/app/models/notification.rb
+++ b/backend/app/models/notification.rb
@@ -1,0 +1,29 @@
+class Notification < ApplicationRecord
+  belongs_to :user
+  belongs_to :actor, class_name: "User"
+  belongs_to :notifiable, polymorphic: true
+
+  validates :user_id, presence: true
+  validates :action, presence: true
+
+  scope :read, -> { where(read: true) }
+  scope :unread, -> { where(read: false) }
+  scope :recent, -> { order(created_at: :desc) }
+  scope :filter_by_tab, ->(tab) {
+    case tab
+    when "unread"
+      unread
+    when "read"
+      read
+    else
+      all
+    end
+  }
+
+  enum action: {
+    liked: "liked",
+    followed: "followed",
+    commented: "commented",
+    published: "published",
+  }
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable
   include DeviseTokenAuth::Concerns::User
+  include Notifiable
 
   before_create :set_default_name, if: :name_blank?
 
@@ -18,6 +19,7 @@ class User < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :liked_bugs, through: :likes, source: :bug
   has_one_attached :image
+  has_many :notifications, dependent: :destroy
 
   PASSWORD_COMPLEXITY_REGEX = /\A(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,128}\z/
   MAX_IMAGE_SIZE = 3.megabytes

--- a/backend/app/serializers/notification_serializer.rb
+++ b/backend/app/serializers/notification_serializer.rb
@@ -1,0 +1,51 @@
+class NotificationSerializer < ActiveModel::Serializer
+  attributes :id, :action, :read, :created_at
+
+  belongs_to :notifiable, polymorphic: true
+  belongs_to :user, serializer: UserSerializer
+  belongs_to :actor, serializer: UserSerializer
+
+  def created_at
+    object.created_at.iso8601
+  end
+
+  def actor
+    object.actor
+  end
+
+  def notifiable
+    {
+      type: object.notifiable.class.name.downcase,
+      title: notifiable_title,
+      bug_id: bug_id,
+    }
+  end
+
+  private
+
+    def notifiable_title
+      case object.notifiable
+      when Bug
+        object.notifiable.title
+      when Comment
+        object.notifiable.bug.title
+      when Like
+        object.notifiable.bug.title
+      else
+        nil
+      end
+    end
+
+    def bug_id
+      case object.notifiable
+      when Bug
+        object.notifiable.id
+      when Comment
+        object.notifiable.bug.id
+      when Like
+        object.notifiable.bug.id
+      else
+        nil
+      end
+    end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -43,6 +43,11 @@ Rails.application.routes.draw do
           end
         end
         resource :profile, only: [:show, :update]
+        resources :notifications, only: [:index, :update, :destroy] do
+          collection do
+            get :header
+          end
+        end
       end
     end
   end

--- a/backend/db/migrate/20250406002611_create_notifications.rb
+++ b/backend/db/migrate/20250406002611_create_notifications.rb
@@ -1,0 +1,13 @@
+class CreateNotifications < ActiveRecord::Migration[7.1]
+  def change
+    create_table :notifications do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :actor, null: false, foreign_key: { to_table: :users }
+      t.references :notifiable, polymorphic: true, null: false
+      t.string :action, null: false, default: 'liked'
+      t.boolean :read, null: false, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_01_064044) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_06_002611) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -124,6 +124,20 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_01_064044) do
     t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
+  create_table "notifications", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "actor_id", null: false
+    t.string "notifiable_type", null: false
+    t.bigint "notifiable_id", null: false
+    t.string "action", default: "liked", null: false
+    t.boolean "read", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["actor_id"], name: "index_notifications_on_actor_id"
+    t.index ["notifiable_type", "notifiable_id"], name: "index_notifications_on_notifiable"
+    t.index ["user_id"], name: "index_notifications_on_user_id"
+  end
+
   create_table "references", force: :cascade do |t|
     t.bigint "bug_id", null: false
     t.string "url", null: false
@@ -180,5 +194,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_01_064044) do
   add_foreign_key "follows", "users", column: "follower_id"
   add_foreign_key "likes", "bugs"
   add_foreign_key "likes", "users"
+  add_foreign_key "notifications", "users"
+  add_foreign_key "notifications", "users", column: "actor_id"
   add_foreign_key "references", "bugs"
 end

--- a/backend/spec/factories/notifications.rb
+++ b/backend/spec/factories/notifications.rb
@@ -1,0 +1,37 @@
+FactoryBot.define do
+  factory :notification do
+    association :user
+    association :actor, factory: :user
+    association :notifiable, factory: :bug
+    action { "liked" }
+    read { false }
+
+    trait :read do
+      read { true }
+    end
+
+    trait :unread do
+      read { false }
+    end
+
+    trait :like do
+      action { "liked" }
+      association :notifiable, factory: :bug
+    end
+
+    trait :comment do
+      action { "commented" }
+      association :notifiable, factory: :comment
+    end
+
+    trait :follow do
+      action { "followed" }
+      association :notifiable, factory: :user
+    end
+
+    trait :published do
+      action { "published" }
+      association :notifiable, factory: :bug
+    end
+  end
+end

--- a/backend/spec/models/concerns/notifiable_spec.rb
+++ b/backend/spec/models/concerns/notifiable_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+class TestNotifiable < ApplicationRecord
+  self.table_name = "bugs"
+  include Notifiable
+  belongs_to :user
+end
+
+RSpec.describe Notifiable, type: :model do
+  let(:user) { create(:user) }
+  let(:actor) { create(:user) }
+  let(:notifiable) { create(:bug, user: user) }
+
+  describe "#create_notification" do
+    context "通知対象がユーザー自身でない場合" do
+      it "通知が作成されること" do
+        expect {
+          notifiable.create_notification(actor, "liked", user)
+        }.to change { Notification.count }.by(1)
+
+        notification = Notification.last
+        expect(notification.user).to eq actor
+        expect(notification.actor).to eq user
+        expect(notification.notifiable).to eq notifiable
+        expect(notification.action).to eq "liked"
+      end
+
+      it "actorが指定されていない場合、notifiableのユーザーがactorになること" do
+        expect {
+          notifiable.create_notification(actor, "liked")
+        }.to change { Notification.count }.by(1)
+
+        notification = Notification.last
+        expect(notification.actor).to eq notifiable.user
+      end
+    end
+
+    context "通知対象がユーザー自身の場合" do
+      it "通知が作成されないこと" do
+        expect {
+          notifiable.create_notification(notifiable.user, "liked", actor)
+        }.not_to change { Notification.count }
+      end
+    end
+  end
+
+  describe "#create_notifications_for_followers" do
+    let(:first_follower) { create(:user) }
+    let(:second_follower) { create(:user) }
+
+    before do
+      first_follower.follow(user)
+      second_follower.follow(user)
+    end
+
+    context "フォロワーが存在する場合" do
+      it "フォロワー全員に通知が作成されること" do
+        expect {
+          notifiable.create_notifications_for_followers("published")
+        }.to change { Notification.count }.by(2)
+
+        notifications = Notification.last(2)
+        expect(notifications.map(&:user)).to contain_exactly(first_follower, second_follower)
+        expect(notifications.map(&:actor)).to all(eq(user))
+        expect(notifications.map(&:notifiable)).to all(eq(notifiable))
+        expect(notifications.map(&:action)).to all(eq("published"))
+      end
+
+      it "フォロワーがnotifiableのユーザー自身の場合は通知が作成されないこと" do
+        user.follow(user)
+        expect {
+          notifiable.create_notifications_for_followers("published")
+        }.to change { Notification.count }.by(2)
+      end
+    end
+
+    context "フォロワーが存在しない場合" do
+      before do
+        user.followers.destroy_all
+      end
+
+      it "通知が作成されないこと" do
+        expect {
+          notifiable.create_notifications_for_followers("published")
+        }.not_to change { Notification.count }
+      end
+    end
+  end
+end

--- a/backend/spec/models/notification_spec.rb
+++ b/backend/spec/models/notification_spec.rb
@@ -1,0 +1,104 @@
+require "rails_helper"
+
+RSpec.describe Notification, type: :model do
+  describe "アソシエーション" do
+    let(:notification) { build(:notification) }
+
+    it "ユーザーに属していること" do
+      expect(notification.user).to be_present
+    end
+
+    it "actor（User）に属していること" do
+      expect(notification.actor).to be_present
+      expect(notification.actor).to be_a(User)
+    end
+
+    it "通知対象（notifiable）に属していること" do
+      expect(notification.notifiable).to be_present
+    end
+  end
+
+  describe "バリデーション" do
+    let(:notification) { build(:notification) }
+
+    it "ユーザーIDが必須であること" do
+      notification.user = nil
+      expect(notification).not_to be_valid
+      expect(notification.errors[:user_id]).to include("を入力してください")
+    end
+
+    it "アクションが必須であること" do
+      notification.action = nil
+      expect(notification).not_to be_valid
+      expect(notification.errors[:action]).to include("を入力してください")
+    end
+  end
+
+  describe "スコープ" do
+    describe "既読/未読フィルター" do
+      before do
+        @read_notification = create(:notification, :read)
+        @unread_notification = create(:notification, :unread)
+      end
+
+      describe ".read" do
+        it "既読の通知のみを返すこと" do
+          expect(Notification.read).to include(@read_notification)
+          expect(Notification.read).not_to include(@unread_notification)
+        end
+      end
+
+      describe ".unread" do
+        it "未読の通知のみを返すこと" do
+          expect(Notification.unread).to include(@unread_notification)
+          expect(Notification.unread).not_to include(@read_notification)
+        end
+      end
+    end
+
+    describe ".filter_by_tab" do
+      before do
+        @read_notification = create(:notification, :read)
+        @unread_notification = create(:notification, :unread)
+      end
+
+      it 'タブが"unread"の場合、未読の通知のみを返すこと' do
+        expect(Notification.filter_by_tab("unread")).to include(@unread_notification)
+        expect(Notification.filter_by_tab("unread")).not_to include(@read_notification)
+      end
+
+      it 'タブが"read"の場合、既読の通知のみを返すこと' do
+        expect(Notification.filter_by_tab("read")).to include(@read_notification)
+        expect(Notification.filter_by_tab("read")).not_to include(@unread_notification)
+      end
+
+      it 'タブが"all"の場合、全ての通知を返すこと' do
+        expect(Notification.filter_by_tab("all")).to include(@read_notification, @unread_notification)
+      end
+    end
+
+    describe ".recent" do
+      before do
+        @old_notification = create(:notification, created_at: 2.days.ago)
+        @new_notification = create(:notification, created_at: 1.day.ago)
+      end
+
+      it "作成日時の降順で通知を返すこと" do
+        expect(Notification.recent.to_a).to eq([@new_notification, @old_notification])
+      end
+    end
+  end
+
+  describe "アクションの種類" do
+    it "いいね、フォロー、コメント、投稿の4種類が定義されていること" do
+      expect(Notification.actions.keys).to contain_exactly("liked", "followed", "commented", "published")
+    end
+
+    it "各アクションの値が正しく設定されていること" do
+      expect(Notification.actions["liked"]).to eq "liked"
+      expect(Notification.actions["followed"]).to eq "followed"
+      expect(Notification.actions["commented"]).to eq "commented"
+      expect(Notification.actions["published"]).to eq "published"
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/mypage/notifications_spec.rb
+++ b/backend/spec/requests/api/v1/mypage/notifications_spec.rb
@@ -1,0 +1,134 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Mypage::Notifications", type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:headers) { user.create_new_auth_token }
+
+  describe "GET /api/v1/mypage/notifications" do
+    before do
+      create(:notification, :like, user: user, read: true)
+      create(:notification, :comment, user: user, read: false)
+      create(:notification, :follow, user: other_user)
+    end
+
+    context "ログインしている場合" do
+      it "現在のユーザーの通知一覧をページネーション付きで返す" do
+        get "/api/v1/mypage/notifications", headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response_json["notifications"].size).to eq(2)
+        expect(response_json["meta"]).to include("current_page", "total_pages", "total_count")
+      end
+
+      it "未読の通知のみを返す" do
+        get "/api/v1/mypage/notifications", params: { tab: "unread" }, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response_json["notifications"].size).to eq(1)
+        expect(response_json["notifications"].first["read"]).to be_falsey
+      end
+
+      it "既読の通知のみを返す" do
+        get "/api/v1/mypage/notifications", params: { tab: "read" }, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response_json["notifications"].size).to eq(1)
+        expect(response_json["notifications"].first["read"]).to be_truthy
+      end
+    end
+
+    context "ログインしていない場合" do
+      it "認証エラーを返す" do
+        get "/api/v1/mypage/notifications"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "GET /api/v1/mypage/notifications/header" do
+    before do
+      create_list(:notification, 6, user: user)
+    end
+
+    context "ログインしている場合" do
+      it "最新5件の通知を返す" do
+        get "/api/v1/mypage/notifications/header", headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response_json.size).to eq(5)
+      end
+    end
+
+    context "ログインしていない場合" do
+      it "認証エラーを返す" do
+        get "/api/v1/mypage/notifications/header"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "PATCH /api/v1/mypage/notifications/:id" do
+    before do
+      @notification = create(:notification, :like, user: user, read: false)
+    end
+
+    context "ログインしている場合" do
+      it "通知を既読にする" do
+        expect {
+          patch "/api/v1/mypage/notifications/#{@notification.id}", headers: headers
+        }.to change { @notification.reload.read }.from(false).to(true)
+
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it "他のユーザーの通知を更新しようとすると404エラーを返す" do
+        other_notification = create(:notification, :comment, user: other_user)
+        patch "/api/v1/mypage/notifications/#{other_notification.id}", headers: headers
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "ログインしていない場合" do
+      it "認証エラーを返す" do
+        patch "/api/v1/mypage/notifications/#{@notification.id}"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "DELETE /api/v1/mypage/notifications/:id" do
+    before do
+      @notification = create(:notification, :follow, user: user)
+    end
+
+    context "ログインしている場合" do
+      it "通知を削除する" do
+        expect {
+          delete "/api/v1/mypage/notifications/#{@notification.id}", headers: headers
+        }.to change { Notification.count }.by(-1)
+
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it "他のユーザーの通知を削除しようとすると404エラーを返す" do
+        other_notification = create(:notification, :like, user: other_user)
+        delete "/api/v1/mypage/notifications/#{other_notification.id}", headers: headers
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "ログインしていない場合" do
+      it "認証エラーを返す" do
+        delete "/api/v1/mypage/notifications/#{@notification.id}"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  images: {
+    domains: ['localhost'],
+  },
 }
 
 module.exports = nextConfig

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -279,27 +279,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.9.tgz",
-      "integrity": "sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
-      "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.27.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -548,9 +548,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
-      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -561,15 +561,15 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
-      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -605,9 +605,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1393,9 +1393,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.24",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.24.tgz",
-      "integrity": "sha512-LAm0Is2KHTNT6IT16lxT+suD0u+VVfYNQqM+EJTKuFRRuY2z+zj01kueWXPCxbMBDt0B5vONYzabHGUNbZYAhA==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.28.tgz",
+      "integrity": "sha512-PAmWhJfJQlP+kxZwCjrVd9QnR5x0R3u0mTXTiZDgSd4h5LdXmjxCCWbN9kq6hkZBOax8Rm3xDW5HagWyJuT37g==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1409,9 +1409,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.24",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.24.tgz",
-      "integrity": "sha512-7Tdi13aojnAZGpapVU6meVSpNzgrFwZ8joDcNS8cJVNuP3zqqrLqeory9Xec5TJZR/stsGJdfwo8KeyloT3+rQ==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.28.tgz",
+      "integrity": "sha512-kzGChl9setxYWpk3H6fTZXXPFFjg7urptLq5o5ZgYezCrqlemKttwMT5iFyx/p1e/JeglTwDFRtb923gTJ3R1w==",
       "cpu": [
         "arm64"
       ],
@@ -1425,9 +1425,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.24",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.24.tgz",
-      "integrity": "sha512-lXR2WQqUtu69l5JMdTwSvQUkdqAhEWOqJEYUQ21QczQsAlNOW2kWZCucA6b3EXmPbcvmHB1kSZDua/713d52xg==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.28.tgz",
+      "integrity": "sha512-z6FXYHDJlFOzVEOiiJ/4NG8aLCeayZdcRSMjPDysW297Up6r22xw6Ea9AOwQqbNsth8JNgIK8EkWz2IDwaLQcw==",
       "cpu": [
         "x64"
       ],
@@ -1441,9 +1441,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.24",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.24.tgz",
-      "integrity": "sha512-nxvJgWOpSNmzidYvvGDfXwxkijb6hL9+cjZx1PVG6urr2h2jUqBALkKjT7kpfurRWicK6hFOvarmaWsINT1hnA==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.28.tgz",
+      "integrity": "sha512-9ARHLEQXhAilNJ7rgQX8xs9aH3yJSj888ssSjJLeldiZKR4D7N08MfMqljk77fAwZsWwsrp8ohHsMvurvv9liQ==",
       "cpu": [
         "arm64"
       ],
@@ -1457,9 +1457,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.24",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.24.tgz",
-      "integrity": "sha512-PaBgOPhqa4Abxa3y/P92F3kklNPsiFjcjldQGT7kFmiY5nuFn8ClBEoX8GIpqU1ODP2y8P6hio6vTomx2Vy0UQ==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.28.tgz",
+      "integrity": "sha512-p6gvatI1nX41KCizEe6JkF0FS/cEEF0u23vKDpl+WhPe/fCTBeGkEBh7iW2cUM0rvquPVwPWdiUR6Ebr/kQWxQ==",
       "cpu": [
         "arm64"
       ],
@@ -1473,9 +1473,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.24",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.24.tgz",
-      "integrity": "sha512-vEbyadiRI7GOr94hd2AB15LFVgcJZQWu7Cdi9cWjCMeCiUsHWA0U5BkGPuoYRnTxTn0HacuMb9NeAmStfBCLoQ==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.28.tgz",
+      "integrity": "sha512-nsiSnz2wO6GwMAX2o0iucONlVL7dNgKUqt/mDTATGO2NY59EO/ZKnKEr80BJFhuA5UC1KZOMblJHWZoqIJddpA==",
       "cpu": [
         "x64"
       ],
@@ -1489,9 +1489,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.24",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.24.tgz",
-      "integrity": "sha512-df0FC9ptaYsd8nQCINCzFtDWtko8PNRTAU0/+d7hy47E0oC17tI54U/0NdGk7l/76jz1J377dvRjmt6IUdkpzQ==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.28.tgz",
+      "integrity": "sha512-+IuGQKoI3abrXFqx7GtlvNOpeExUH1mTIqCrh1LGFf8DnlUcTmOOCApEnPJUSLrSbzOdsF2ho2KhnQoO0I1RDw==",
       "cpu": [
         "x64"
       ],
@@ -1505,9 +1505,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.24",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.24.tgz",
-      "integrity": "sha512-ZEntbLjeYAJ286eAqbxpZHhDFYpYjArotQ+/TW9j7UROh0DUmX7wYDGtsTPpfCV8V+UoqHBPU7q9D4nDNH014Q==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.28.tgz",
+      "integrity": "sha512-l61WZ3nevt4BAnGksUVFKy2uJP5DPz2E0Ma/Oklvo3sGj9sw3q7vBWONFRgz+ICiHpW5mV+mBrkB3XEubMrKaA==",
       "cpu": [
         "arm64"
       ],
@@ -1521,9 +1521,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.24",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.24.tgz",
-      "integrity": "sha512-9KuS+XUXM3T6v7leeWU0erpJ6NsFIwiTFD5nzNg8J5uo/DMIPvCp3L1Ao5HjbHX0gkWPB1VrKoo/Il4F0cGK2Q==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.28.tgz",
+      "integrity": "sha512-+Kcp1T3jHZnJ9v9VTJ/yf1t/xmtFAc/Sge4v7mVc1z+NYfYzisi8kJ9AsY8itbgq+WgEwMtOpiLLJsUy2qnXZw==",
       "cpu": [
         "ia32"
       ],
@@ -1537,9 +1537,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.24",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.24.tgz",
-      "integrity": "sha512-cXcJ2+x0fXQ2CntaE00d7uUH+u1Bfp/E0HsNQH79YiLaZE5Rbm7dZzyAYccn3uICM7mw+DxoMqEfGXZtF4Fgaw==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.28.tgz",
+      "integrity": "sha512-1gCmpvyhz7DkB1srRItJTnmR2UwQPAUXXIg9r0/56g3O8etGmwlX68skKXJOp9EejW3hhv7nSQUJ2raFiz4MoA==",
       "cpu": [
         "x64"
       ],
@@ -2750,9 +2750,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -3118,9 +3118,9 @@
       }
     },
     "node_modules/camelcase-keys/node_modules/type-fest": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.35.0.tgz",
-      "integrity": "sha512-2/AwEFQDFEy30iOLjrvHDIH7e4HEWH+f1Yl1bI5XMqzuoCUqwYCdxachgsgv0og/JdVZUhbfjcJAoHj5L1753A==",
+      "version": "4.39.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.39.1.tgz",
+      "integrity": "sha512-uW9qzd66uyHYxwyVBYiwS4Oi0qZyUqwjU+Oevr6ZogYiXt99EOYtwvzMSLw1c3lYo2HzJsep/NB23iEVEgjG/w==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
@@ -7662,12 +7662,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "14.2.24",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.24.tgz",
-      "integrity": "sha512-En8VEexSJ0Py2FfVnRRh8gtERwDRaJGNvsvad47ShkC2Yi8AXQPXEA2vKoDJlGFSj5WE5SyF21zNi4M5gyi+SQ==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.28.tgz",
+      "integrity": "sha512-QLEIP/kYXynIxtcKB6vNjtWLVs3Y4Sb+EClTC/CSVzdLD1gIuItccpu/n1lhmduffI32iPGEK2cLLxxt28qgYA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "14.2.24",
+        "@next/env": "14.2.28",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -7682,15 +7682,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.24",
-        "@next/swc-darwin-x64": "14.2.24",
-        "@next/swc-linux-arm64-gnu": "14.2.24",
-        "@next/swc-linux-arm64-musl": "14.2.24",
-        "@next/swc-linux-x64-gnu": "14.2.24",
-        "@next/swc-linux-x64-musl": "14.2.24",
-        "@next/swc-win32-arm64-msvc": "14.2.24",
-        "@next/swc-win32-ia32-msvc": "14.2.24",
-        "@next/swc-win32-x64-msvc": "14.2.24"
+        "@next/swc-darwin-arm64": "14.2.28",
+        "@next/swc-darwin-x64": "14.2.28",
+        "@next/swc-linux-arm64-gnu": "14.2.28",
+        "@next/swc-linux-arm64-musl": "14.2.28",
+        "@next/swc-linux-x64-gnu": "14.2.28",
+        "@next/swc-linux-x64-musl": "14.2.28",
+        "@next/swc-win32-arm64-msvc": "14.2.28",
+        "@next/swc-win32-ia32-msvc": "14.2.28",
+        "@next/swc-win32-x64-msvc": "14.2.28"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",

--- a/frontend/src/__tests__/components/layouts/Header.test.tsx
+++ b/frontend/src/__tests__/components/layouts/Header.test.tsx
@@ -1,11 +1,46 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { Header } from '@/components/layouts/Header'
 import { AuthContext } from '@/context/AuthContext'
 import { useAuth } from '@/hooks/useAuth'
 
 jest.mock('@/hooks/useAuth')
+jest.mock('@/hooks/useNotificationRead', () => ({
+  useNotificationRead: () => ({
+    markAsRead: jest.fn(),
+  }),
+}))
+jest.mock('@/hooks/useNotificationMessage', () => ({
+  useNotificationMessage: () => ({
+    getMessage: jest.fn(),
+  }),
+}))
+jest.mock('@/utils', () => ({
+  fetcher: jest.fn(),
+}))
+jest.mock('@tanstack/react-query', () => ({
+  ...jest.requireActual('@tanstack/react-query'),
+  useQuery: (key: string) => {
+    if (key === 'notifications') {
+      return { data: [], isLoading: false, error: null }
+    }
+    return { data: null, isLoading: false, error: null }
+  },
+}))
 
 describe('Header', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+  })
+
   it('未認証の場合、ログインと新規登録リンクが表示されること', () => {
     ;(useAuth as jest.Mock).mockReturnValue({
       isFetched: true,
@@ -14,18 +49,20 @@ describe('Header', () => {
     })
 
     render(
-      <AuthContext.Provider
-        value={{
-          currentUser: null,
-          isAuthenticated: false,
-          isFetched: true,
-          setCurrentUser: jest.fn(),
-          setIsAuthenticated: jest.fn(),
-          signout: jest.fn(),
-        }}
-      >
-        <Header />
-      </AuthContext.Provider>,
+      <QueryClientProvider client={queryClient}>
+        <AuthContext.Provider
+          value={{
+            currentUser: null,
+            isAuthenticated: false,
+            isFetched: true,
+            setCurrentUser: jest.fn(),
+            setIsAuthenticated: jest.fn(),
+            signout: jest.fn(),
+          }}
+        >
+          <Header />
+        </AuthContext.Provider>
+      </QueryClientProvider>,
     )
 
     expect(screen.getByText('新規登録')).toBeInTheDocument()
@@ -40,18 +77,20 @@ describe('Header', () => {
     })
 
     render(
-      <AuthContext.Provider
-        value={{
-          currentUser: { id: 1, name: 'Test User', imageUrl: 'test.com' },
-          isAuthenticated: true,
-          isFetched: true,
-          setCurrentUser: jest.fn(),
-          setIsAuthenticated: jest.fn(),
-          signout: jest.fn(),
-        }}
-      >
-        <Header />
-      </AuthContext.Provider>,
+      <QueryClientProvider client={queryClient}>
+        <AuthContext.Provider
+          value={{
+            currentUser: { id: 1, name: 'Test User', imageUrl: 'test.com' },
+            isAuthenticated: true,
+            isFetched: true,
+            setCurrentUser: jest.fn(),
+            setIsAuthenticated: jest.fn(),
+            signout: jest.fn(),
+          }}
+        >
+          <Header />
+        </AuthContext.Provider>
+      </QueryClientProvider>,
     )
 
     expect(screen.getByText('マイページ')).toBeInTheDocument()
@@ -68,18 +107,20 @@ describe('Header', () => {
     })
 
     render(
-      <AuthContext.Provider
-        value={{
-          currentUser: { id: 1, name: 'Test User', imageUrl: 'test.com' },
-          isAuthenticated: true,
-          isFetched: true,
-          setCurrentUser: jest.fn(),
-          setIsAuthenticated: jest.fn(),
-          signout: mockSignout,
-        }}
-      >
-        <Header />
-      </AuthContext.Provider>,
+      <QueryClientProvider client={queryClient}>
+        <AuthContext.Provider
+          value={{
+            currentUser: { id: 1, name: 'Test User', imageUrl: 'test.com' },
+            isAuthenticated: true,
+            isFetched: true,
+            setCurrentUser: jest.fn(),
+            setIsAuthenticated: jest.fn(),
+            signout: mockSignout,
+          }}
+        >
+          <Header />
+        </AuthContext.Provider>
+      </QueryClientProvider>,
     )
 
     fireEvent.click(screen.getByText('ログアウト'))

--- a/frontend/src/__tests__/pages/auth/confirmation.test.tsx
+++ b/frontend/src/__tests__/pages/auth/confirmation.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen, waitFor } from '@testing-library/react'
 import axios from 'axios'
 import { NextRouter, useRouter } from 'next/router'
@@ -21,6 +22,7 @@ jest.mock('react-toastify', () => ({
 
 describe('Confirmation', () => {
   let mockRouter: NextRouter
+  let queryClient: QueryClient
 
   beforeEach(() => {
     mockRouter = {
@@ -29,13 +31,23 @@ describe('Confirmation', () => {
       push: jest.fn(),
     } as unknown as NextRouter
     ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
+
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
   })
 
   it('ローディングメッセージが表示される', () => {
     render(
-      <AuthProvider>
-        <Confirmation />
-      </AuthProvider>,
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <Confirmation />
+        </AuthProvider>
+      </QueryClientProvider>,
     )
     expect(
       screen.getByText('アカウントを有効化しています...'),
@@ -47,9 +59,11 @@ describe('Confirmation', () => {
     ;(axios.patch as jest.Mock).mockResolvedValue({})
 
     render(
-      <AuthProvider>
-        <Confirmation />
-      </AuthProvider>,
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <Confirmation />
+        </AuthProvider>
+      </QueryClientProvider>,
     )
 
     await waitFor(() => {
@@ -71,9 +85,11 @@ describe('Confirmation', () => {
     })
 
     render(
-      <AuthProvider>
-        <Confirmation />
-      </AuthProvider>,
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <Confirmation />
+        </AuthProvider>
+      </QueryClientProvider>,
     )
 
     await waitFor(() => {
@@ -86,9 +102,11 @@ describe('Confirmation', () => {
     mockRouter.query = {}
 
     render(
-      <AuthProvider>
-        <Confirmation />
-      </AuthProvider>,
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <Confirmation />
+        </AuthProvider>
+      </QueryClientProvider>,
     )
 
     await waitFor(() => {

--- a/frontend/src/__tests__/pages/auth/email-sent.test.tsx
+++ b/frontend/src/__tests__/pages/auth/email-sent.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
 import EmailSent from '@/pages/auth/email-sent'
 import { AuthProvider } from '@/providers/AuthProvider'
@@ -12,10 +13,14 @@ jest.mock('next/router', () => ({
 
 describe('EmailSent', () => {
   it('確認メッセージが表示されること', () => {
+    const queryClient = new QueryClient({})
+
     render(
-      <AuthProvider>
-        <EmailSent />,
-      </AuthProvider>,
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <EmailSent />,
+        </AuthProvider>
+      </QueryClientProvider>,
     )
 
     expect(screen.getByText('確認メールを送信しました')).toBeInTheDocument()

--- a/frontend/src/components/MypageLayout.tsx
+++ b/frontend/src/components/MypageLayout.tsx
@@ -25,6 +25,13 @@ export const MypageLayout = ({ children }: { children: ReactNode }) => {
             <li className={isActive('/mypage/follows') ? 'text-primary' : ''}>
               <Link href="/mypage/follows">フォロー・フォロワー</Link>
             </li>
+            <li
+              className={
+                isActive('/mypage/notifications') ? 'text-primary' : ''
+              }
+            >
+              <Link href="/mypage/notifications">通知</Link>
+            </li>
             <li className={isActive('/mypage/profile') ? 'text-primary' : ''}>
               <Link href="/mypage/profile">プロフィール</Link>
             </li>

--- a/frontend/src/components/layouts/Header.tsx
+++ b/frontend/src/components/layouts/Header.tsx
@@ -1,10 +1,34 @@
+import { useQuery } from '@tanstack/react-query'
 import Image from 'next/image'
 import Link from 'next/link'
-import { FaPen } from 'react-icons/fa'
+import { FaPen, FaBell } from 'react-icons/fa'
+import { Notification } from '@/features/notification/types/Notification'
 import { useAuth } from '@/hooks/useAuth'
+import { useNotificationMessage } from '@/hooks/useNotificationMessage'
+import { useNotificationRead } from '@/hooks/useNotificationRead'
+import { fetcher } from '@/utils'
+import { API_URLS } from '@/utils/api'
 
 export const Header = () => {
   const { currentUser, isFetched, isAuthenticated, signout } = useAuth()
+  const { markAsRead } = useNotificationRead()
+  const { getMessage } = useNotificationMessage()
+
+  const { data: notifications } = useQuery<Notification[]>({
+    queryKey: ['notifications'],
+    queryFn: () => fetcher(API_URLS.MYPAGE.NOTIFICATIONS.HEADER),
+    enabled: isAuthenticated,
+  })
+
+  const handleNotificationClick = (notification: Notification) => {
+    if (!notification.read) {
+      markAsRead(notification.id.toString())
+    }
+  }
+
+  const unreadCount =
+    notifications?.filter((notification) => !notification.read).length || 0
+
   return (
     <div className="navbar bg-base-100 shadow-xl">
       <div className="flex-1">
@@ -22,6 +46,75 @@ export const Header = () => {
                     <FaPen className="text-xl text-primary" />
                   </button>
                 </Link>
+                <div className="dropdown dropdown-end">
+                  <div
+                    tabIndex={0}
+                    role="button"
+                    className="btn btn-circle btn-ghost"
+                  >
+                    <div className="indicator">
+                      <FaBell className="text-xl" />
+                      {unreadCount > 0 && (
+                        <span className="badge indicator-item badge-sm bg-red-500 text-white">
+                          {unreadCount}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <ul
+                    tabIndex={0}
+                    className="menu dropdown-content rounded-box menu-sm z-[1] mt-3 w-80 bg-base-100 p-2 shadow"
+                  >
+                    {notifications?.slice(0, 5).map((notification) => (
+                      <div
+                        key={notification.id}
+                        className={`cursor-pointer p-3 hover:bg-gray-100 ${
+                          notification.read ? 'bg-white' : 'bg-blue-50'
+                        }`}
+                        onClick={() => handleNotificationClick(notification)}
+                      >
+                        <div className="flex items-center justify-between">
+                          <div className="flex items-center space-x-3">
+                            <Link
+                              href={`/users/${notification.actor?.id}`}
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              <Image
+                                src={
+                                  notification.actor?.imageUrl ||
+                                  '/images/default-avatar.png'
+                                }
+                                alt={notification.actor?.name || 'ユーザー'}
+                                width={32}
+                                height={32}
+                                className="size-8 rounded-full transition-opacity hover:opacity-80"
+                                unoptimized
+                              />
+                            </Link>
+                            <div>
+                              <p className="text-sm text-gray-600">
+                                {getMessage(notification)}
+                              </p>
+                              <p className="mt-1 text-xs text-gray-500">
+                                {new Date(
+                                  notification.createdAt,
+                                ).toLocaleString()}
+                              </p>
+                            </div>
+                          </div>
+                          {!notification.read && (
+                            <div className="size-2 rounded-full bg-blue-500" />
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                    <li className="text-center">
+                      <Link href="/mypage/notifications" className="text-sm">
+                        通知一覧を見る
+                      </Link>
+                    </li>
+                  </ul>
+                </div>
                 <div className="dropdown dropdown-end">
                   <div
                     tabIndex={0}

--- a/frontend/src/components/notifications/NotificationListItem.tsx
+++ b/frontend/src/components/notifications/NotificationListItem.tsx
@@ -1,0 +1,75 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import { FaTrash } from 'react-icons/fa'
+import { Notification } from '@/features/notification/types/Notification'
+import { useNotificationMessage } from '@/hooks/useNotificationMessage'
+
+type Props = {
+  notification: Notification
+  isUpdating: boolean
+  onNotificationClick: (notification: Notification) => void
+  onDelete: (notification: Notification) => void
+}
+
+export const NotificationListItem = ({
+  notification,
+  isUpdating,
+  onNotificationClick,
+  onDelete,
+}: Props) => {
+  const { getMessage } = useNotificationMessage()
+  const handleDelete = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    onDelete(notification)
+  }
+
+  return (
+    <button
+      onClick={() => onNotificationClick(notification)}
+      className={`w-full rounded-lg p-4 text-left transition-colors ${
+        notification.read
+          ? 'bg-base-100 hover:bg-base-100'
+          : 'bg-blue-50 hover:bg-blue-100'
+      }`}
+      disabled={isUpdating}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-4">
+          <Link
+            href={`/users/${notification.actor?.id}`}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Image
+              src={notification.actor?.imageUrl || '/images/default-avatar.png'}
+              alt={notification.actor?.name || 'ユーザー'}
+              width={40}
+              height={40}
+              className="size-10 rounded-full transition-opacity hover:opacity-80"
+              unoptimized
+            />
+          </Link>
+          <div>
+            <p className="text-sm text-gray-600">{getMessage(notification)}</p>
+            <p className="mt-1 text-xs text-gray-500">
+              {new Date(notification.createdAt).toLocaleString()}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center space-x-2">
+          {!notification.read && (
+            <div className="size-2 rounded-full bg-blue-500" />
+          )}
+          {notification.read && (
+            <button
+              onClick={handleDelete}
+              className="p-2 text-gray-400 transition-colors hover:text-red-500"
+              disabled={isUpdating}
+            >
+              <FaTrash />
+            </button>
+          )}
+        </div>
+      </div>
+    </button>
+  )
+}

--- a/frontend/src/features/bugs/ui/CancelButton.tsx
+++ b/frontend/src/features/bugs/ui/CancelButton.tsx
@@ -10,7 +10,7 @@ export const CancelButton = ({ onClick }: CancelButtonProps) => {
   return (
     <button
       type="button"
-      onClick={onClick ?? (() => router.push('/'))}
+      onClick={onClick ?? (() => router.back())}
       className="btn btn-outline w-32 bg-white px-6"
     >
       キャンセル

--- a/frontend/src/features/mypage/types/TabValue.ts
+++ b/frontend/src/features/mypage/types/TabValue.ts
@@ -7,3 +7,5 @@ export type TabValue =
   | 'liked'
 
 export type FollowTabValue = 'followers' | 'following'
+
+export type NotificationTabValue = 'all' | 'unread' | 'read'

--- a/frontend/src/features/notification/types/Notification.ts
+++ b/frontend/src/features/notification/types/Notification.ts
@@ -1,0 +1,22 @@
+export type Notification = {
+  id: number
+  action: 'liked' | 'followed' | 'commented' | 'published'
+  read: boolean
+  createdAt: string
+  notifiable: {
+    id: number
+    type: string
+    title?: string
+    bugId?: number
+  }
+  user: {
+    id: number
+    name: string
+    imageUrl: string | null
+  }
+  actor: {
+    id: number
+    name: string
+    imageUrl: string | null
+  }
+}

--- a/frontend/src/features/user/components/FollowButton.tsx
+++ b/frontend/src/features/user/components/FollowButton.tsx
@@ -16,7 +16,7 @@ export const FollowButton = ({
       className={`group btn w-24 p-0.5 text-xs transition-colors duration-300 md:w-32 md:p-2 md:text-base ${
         isFollowing
           ? 'bg-black text-white hover:bg-red-600'
-          : 'border border-black bg-white text-black hover:bg-gray-100'
+          : 'bg-gray-200 text-black hover:bg-gray-300'
       }`}
       disabled={isLoading}
       onClick={isFollowing ? onUnfollow : onFollow}

--- a/frontend/src/hooks/useNotificationMessage.tsx
+++ b/frontend/src/hooks/useNotificationMessage.tsx
@@ -1,0 +1,50 @@
+import Link from 'next/link'
+import { Notification } from '@/features/notification/types/Notification'
+
+const getNotifiableLink = (notification: Notification) => {
+  if (notification.notifiable.bugId) {
+    return `/bugs/${notification.notifiable.bugId}`
+  }
+  return '#'
+}
+
+export const useNotificationMessage = () => {
+  const getMessage = (notification: Notification) => {
+    if (!notification.actor) return ''
+
+    const actorName = `${notification.actor.name}さんが`
+    const title = notification.notifiable.title
+    const link = (
+      <Link
+        href={getNotifiableLink(notification)}
+        onClick={(e) => e.stopPropagation()}
+        className="text-blue-500 hover:underline"
+      >
+        {title}
+      </Link>
+    )
+
+    switch (notification.action) {
+      case 'liked':
+        return (
+          <>
+            {actorName}「{link}」にいいねしました
+          </>
+        )
+      case 'followed':
+        return `${actorName}フォローしました`
+      case 'commented':
+        return (
+          <>
+            {actorName}「{link}」にコメントしました
+          </>
+        )
+      case 'published':
+        return `${actorName}バグを投稿しました`
+      default:
+        return ''
+    }
+  }
+
+  return { getMessage }
+}

--- a/frontend/src/hooks/useNotificationRead.ts
+++ b/frontend/src/hooks/useNotificationRead.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import axios from 'axios'
+import { API_URLS } from '@/utils/api'
+import { getAuthHeaders } from '@/utils/headers'
+
+export const useNotificationRead = () => {
+  const queryClient = useQueryClient()
+
+  const { mutate: markAsRead, isPending: isUpdating } = useMutation({
+    mutationFn: async (notificationId: string) => {
+      const response = await axios.patch(
+        API_URLS.MYPAGE.NOTIFICATIONS.UPDATE(notificationId),
+        {},
+        {
+          headers: getAuthHeaders() ?? {},
+        },
+      )
+      return response.data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['notifications'] })
+    },
+  })
+
+  const handleNotificationRead = (notificationId: string) => {
+    if (!isUpdating) {
+      markAsRead(notificationId)
+    }
+  }
+
+  return {
+    markAsRead: handleNotificationRead,
+    isUpdating,
+  }
+}

--- a/frontend/src/pages/mypage/follows.tsx
+++ b/frontend/src/pages/mypage/follows.tsx
@@ -111,7 +111,7 @@ const FollowIndex = () => {
 
   return (
     <MypageLayout>
-      <div className="mx-auto my-12 w-full max-w-full p-4 md:max-w-4xl lg:max-w-3xl">
+      <div className="mx-auto w-full max-w-full md:max-w-4xl lg:max-w-3xl">
         <div className="mt-8 flex justify-center">
           <Tabs<FollowTabValue>
             tabs={tabs}

--- a/frontend/src/pages/mypage/notifications.tsx
+++ b/frontend/src/pages/mypage/notifications.tsx
@@ -66,7 +66,6 @@ const Notifications = () => {
       return response.data
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['notifications', page, tab] })
       queryClient.invalidateQueries({ queryKey: ['notifications'] })
     },
   })

--- a/frontend/src/pages/mypage/notifications.tsx
+++ b/frontend/src/pages/mypage/notifications.tsx
@@ -1,0 +1,173 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import axios from 'axios'
+import { useRouter } from 'next/router'
+import { useState } from 'react'
+import { MypageLayout } from '@/components/MypageLayout'
+import { NotificationListItem } from '@/components/notifications/NotificationListItem'
+import { DeleteModal } from '@/components/utilities/DeleteModal'
+import { Loading } from '@/components/utilities/Loading'
+import { NoData } from '@/components/utilities/NoData'
+import { Pagination } from '@/components/utilities/Pagination'
+import { Tab } from '@/features/mypage/types/Tab'
+import { NotificationTabValue } from '@/features/mypage/types/TabValue'
+import { Tabs } from '@/features/mypage/ui/Tabs'
+import { Notification } from '@/features/notification/types/Notification'
+import { useAuth } from '@/hooks/useAuth'
+import { useNotificationRead } from '@/hooks/useNotificationRead'
+import { useRequiredSignedIn } from '@/hooks/useRequiredSignedIn'
+import { Meta } from '@/types/Meta'
+import { fetcher } from '@/utils'
+import { API_URLS } from '@/utils/api'
+import { getAuthHeaders } from '@/utils/headers'
+
+const tabs: Tab<NotificationTabValue>[] = [
+  {
+    label: `全て`,
+    value: 'all',
+  },
+  {
+    label: '未読',
+    value: 'unread',
+  },
+  {
+    label: '既読',
+    value: 'read',
+  },
+]
+
+const Notifications = () => {
+  useRequiredSignedIn()
+  const { currentUser } = useAuth()
+  const queryClient = useQueryClient()
+  const router = useRouter()
+  const [notificationToDelete, setNotificationToDelete] =
+    useState<Notification | null>(null)
+  const page = Number(router.query.page) || 1
+  const tab = (router.query.tab as NotificationTabValue) || 'all'
+  const { markAsRead, isUpdating } = useNotificationRead()
+
+  const { data, isPending } = useQuery<{
+    notifications: Notification[]
+    meta: Meta
+  }>({
+    queryKey: ['notifications', page, tab],
+    queryFn: () => fetcher(API_URLS.MYPAGE.NOTIFICATIONS.INDEX(page, tab)),
+    enabled: !!currentUser,
+  })
+
+  const { mutate: deleteNotification, isPending: isDeleting } = useMutation({
+    mutationFn: async (notificationId: string) => {
+      const response = await axios.delete(
+        API_URLS.MYPAGE.NOTIFICATIONS.DELETE(notificationId),
+        {
+          headers: getAuthHeaders() ?? {},
+        },
+      )
+      return response.data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['notifications', page, tab] })
+      queryClient.invalidateQueries({ queryKey: ['notifications'] })
+    },
+  })
+
+  const handleNotificationClick = (notification: Notification) => {
+    if (!notification.read) {
+      markAsRead(notification.id.toString())
+    }
+  }
+
+  const handleDelete = (notification: Notification) => {
+    setNotificationToDelete(notification)
+  }
+
+  const handleDeleteConfirm = () => {
+    if (notificationToDelete && !isDeleting) {
+      deleteNotification(notificationToDelete.id.toString())
+      setNotificationToDelete(null)
+    }
+  }
+
+  const handleDeleteCancel = () => {
+    setNotificationToDelete(null)
+  }
+
+  const handlePageChange = (newPage: number) => {
+    router.push({
+      pathname: router.pathname,
+      query: { ...router.query, page: newPage },
+    })
+  }
+
+  const handleTabChange = (tab: NotificationTabValue) => {
+    router.push({
+      pathname: router.pathname,
+      query: { ...router.query, tab: tab, page: 1 },
+    })
+  }
+
+  if (isPending) {
+    return (
+      <MypageLayout>
+        <div className="container mx-auto px-4">
+          <div className="mx-auto max-w-2xl">
+            <div className="mt-8 flex justify-center">
+              <Tabs tabs={tabs} selectedTab={tab} onClick={handleTabChange} />
+            </div>
+            <Loading message="通知を読み込み中..." />
+          </div>
+        </div>
+      </MypageLayout>
+    )
+  }
+
+  return (
+    <MypageLayout>
+      <div className="container mx-auto px-4">
+        <div className="mx-auto max-w-2xl">
+          <div className="mt-8 flex justify-center">
+            <Tabs tabs={tabs} selectedTab={tab} onClick={handleTabChange} />
+          </div>
+          <div className="mt-4 text-right font-bold text-gray-600">
+            <span className="text-2xl">{data?.notifications?.length}</span>件 /{' '}
+            <span className="text-2xl">{data?.meta?.totalCount}</span>件
+          </div>
+          {!data || data.notifications.length === 0 ? (
+            <NoData message="通知はありません" />
+          ) : (
+            <>
+              <div className="mt-8 space-y-4">
+                {data.notifications.map((notification) => (
+                  <NotificationListItem
+                    key={notification.id}
+                    notification={notification}
+                    isUpdating={isUpdating || isDeleting}
+                    onNotificationClick={handleNotificationClick}
+                    onDelete={handleDelete}
+                  />
+                ))}
+              </div>
+              <div className="flex justify-center py-10">
+                <Pagination
+                  currentPage={data.meta.currentPage}
+                  totalPages={data.meta.totalPages}
+                  onChange={handlePageChange}
+                />
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+      {notificationToDelete && (
+        <DeleteModal
+          title="通知を削除"
+          description="この通知を削除してもよろしいですか？"
+          onClose={handleDeleteCancel}
+          onClick={handleDeleteConfirm}
+        />
+      )}
+    </MypageLayout>
+  )
+}
+
+export default Notifications

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -53,5 +53,12 @@ export const API_URLS = {
       SHOW: `${baseUrl}/mypage/profile`,
       UPDATE: `${baseUrl}/mypage/profile`,
     },
+    NOTIFICATIONS: {
+      INDEX: (page: number, tab: string) =>
+        `${baseUrl}/mypage/notifications?page=${page}&tab=${tab}`,
+      HEADER: `${baseUrl}/mypage/notifications/header`,
+      UPDATE: (id: string) => `${baseUrl}/mypage/notifications/${id}`,
+      DELETE: (id: string) => `${baseUrl}/mypage/notifications/${id}`,
+    },
   },
 }


### PR DESCRIPTION
## 概要

通知作成、一覧取得、削除機能実装

## 関連するissue番号

- #20
- #48 

## 行ったこと

- バグを公開した時にフォロワーに通知される機能実装
- いいねした時、コメントした時にそのバグの投稿者に通知される機能実装
- フォローした時に相手に通知される機能実装
- マイページに通知一覧機能実装
- ヘッダーで最新の通知を5件表示する機能実装
- 通知削除機能実装
- 通知関連のテスト作成

## 動作確認

フロントエンド http://localhost:8080/mypage/notifications
バックエンド http://localhost:3100/api/v1/mypage/notifications

## その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an in-app notification system that alerts users when content is liked, followed, commented on, or published.
	- Added a dedicated notifications page where users can view, mark, and delete notifications with clear filters (all, unread, read).
	- Enhanced the header with a dropdown displaying the latest notifications and an unread count badge, improving overall user navigation and awareness.
	- Implemented pagination for notifications and the ability to fetch the latest notifications in the header.
	- Added functionality to mark notifications as read and delete them directly from the notifications page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->